### PR TITLE
Set the decoded value in the instance variable

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -78,6 +78,7 @@ module Vault
           ciphertext = Vault::Rails.encrypt(path, key, plaintext)
           write_attribute(encrypted_column, ciphertext)
 
+          plaintext = serializer.decode(plaintext) if serializer
           instance_variable_set(:"@#{column}", plaintext)
         end
 


### PR DESCRIPTION
This fixes an issue where the encoded value would be saved on the instance variable, but that was not the actual value that would be returned on a reload.