### PR TITLE
Track dirty attributes

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -95,17 +95,17 @@ module Vault
           read_attribute(encrypted_column).present?
         end
 
-        # Ditry method
+        # Dirty method
         define_method("#{column}_change") do
           changes[column]
         end
 
-        # Ditry method
+        # Dirty method
         define_method("#{column}_changed?") do
           changed.include?(column.to_s)
         end
 
-        # Ditry method
+        # Dirty method
         define_method("#{column}_was") do
           if changes[column]
             changes[column][0]

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -110,7 +110,7 @@ module Vault
           if changes[column]
             changes[column][0]
           else
-            nil
+            public_send(column)
           end
         end
 

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -24,6 +24,11 @@ describe Vault::Rails do
 
     it "tracks dirty attributes" do
       person = Person.create!(ssn: "123-45-6789")
+
+      expect(person.ssn_changed?).to be(false)
+      expect(person.ssn_change).to be(nil)
+      expect(person.ssn_was).to eq("123-45-6789")
+
       person.ssn = "111-11-1111"
 
       expect(person.ssn_changed?).to be(true)
@@ -75,6 +80,11 @@ describe Vault::Rails do
 
     it "tracks dirty attributes" do
       person = Person.create!(credit_card: "1234567890111213")
+
+      expect(person.credit_card_changed?).to be(false)
+      expect(person.credit_card_change).to eq(nil)
+      expect(person.credit_card_was).to eq("1234567890111213")
+
       person.credit_card = "123456789010"
 
       expect(person.credit_card_changed?).to be(true)
@@ -109,8 +119,22 @@ describe Vault::Rails do
       expect(person.details).to eq({})
     end
 
+    it "tracks dirty attributes" do
+      person = Person.create!(details: { "foo" => "bar" })
+
+      expect(person.details_changed?).to be(false)
+      expect(person.details_change).to be(nil)
+      expect(person.details_was).to eq({ "foo" => "bar" })
+
+      person.details = { "zip" => "zap" }
+
+      expect(person.details_changed?).to be(true)
+      expect(person.details_change).to eq([{ "foo" => "bar" }, { "zip" => "zap" }])
+      expect(person.details_was).to eq({ "foo" => "bar" })
+    end
+
     it "encodes and decodes attributes" do
-      person = Person.create!(details: { foo: "bar", "zip" => 1 })
+      person = Person.create!(details: { "foo" => "bar", "zip" => 1 })
       person.reload
 
       raw = Vault::Rails.decrypt("transit", "dummy_people_details", person.details_encrypted)

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -22,6 +22,15 @@ describe Vault::Rails do
       expect(person.ssn).to eq("123-45-6789")
     end
 
+    it "tracks dirty attributes" do
+      person = Person.create!(ssn: "123-45-6789")
+      person.ssn = "111-11-1111"
+
+      expect(person.ssn_changed?).to be(true)
+      expect(person.ssn_change).to eq(["123-45-6789", "111-11-1111"])
+      expect(person.ssn_was).to eq("123-45-6789")
+    end
+
     it "allows attributes to be unset" do
       person = Person.create!(ssn: "123-45-6789")
       person.update_attributes!(ssn: nil)
@@ -62,6 +71,15 @@ describe Vault::Rails do
       person.reload
 
       expect(person.credit_card).to eq("1234567890111213")
+    end
+
+    it "tracks dirty attributes" do
+      person = Person.create!(credit_card: "1234567890111213")
+      person.credit_card = "123456789010"
+
+      expect(person.credit_card_changed?).to be(true)
+      expect(person.credit_card_change).to eq(["1234567890111213", "123456789010"])
+      expect(person.credit_card_was).to eq("1234567890111213")
     end
 
     it "allows attributes to be unset" do

--- a/spec/unit/encrypted_model_spec.rb
+++ b/spec/unit/encrypted_model_spec.rb
@@ -19,5 +19,27 @@ describe Vault::EncryptedModel do
         klass.vault_attribute(:foo, serializer: :json, decode: ->(r) { r })
       }.to raise_error(Vault::Rails::ValidationFailedError)
     end
+
+    it "defines a getter" do
+      klass.vault_attribute(:foo)
+      expect(klass.instance_methods).to include(:foo)
+    end
+
+    it "defines a setter" do
+      klass.vault_attribute(:foo)
+      expect(klass.instance_methods).to include(:foo=)
+    end
+
+    it "defines a checker" do
+      klass.vault_attribute(:foo)
+      expect(klass.instance_methods).to include(:foo?)
+    end
+
+    it "defines dirty attribute methods" do
+      klass.vault_attribute(:foo)
+      expect(klass.instance_methods).to include(:foo_change)
+      expect(klass.instance_methods).to include(:foo_changed?)
+      expect(klass.instance_methods).to include(:foo_was)
+    end
   end
 end


### PR DESCRIPTION
This leverage's ActiveRecord's dirty attribute tracking to allow users to query before/after values when saving a model.