### PR TITLE
Vault::Rails with default options allows attributes to be unset after reload

### DIFF
--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -48,6 +48,16 @@ describe Vault::Rails do
       expect(person.ssn).to be(nil)
     end
 
+    it "allows attributes to be unset after reload" do
+      person = Person.create!(ssn: "123-45-6789")
+      person.reload
+      person.ssn = nil
+      person.save!
+      person.reload
+
+      expect(person.ssn).to be(nil)
+    end
+
     it "allows attributes to be blank" do
       person = Person.create!(ssn: "123-45-6789")
       person.update_attributes!(ssn: "")


### PR DESCRIPTION
This spec reproduces a bug that I encountered when trying to set the value of a `vault_attribute` to `nil`. There's no fix in the PR, just a reproduction of the bug, per @sethvargo.