### PR TITLE
Load and persist Vault attribute at init and save

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -35,10 +35,10 @@ module Vault
       #   a proc to encode the value with
       # @option options [Proc] :decode
       #   a proc to decode the value with
-      def vault_attribute(column, options = {})
-        encrypted_column = options[:encrypted_column] || "#{column}_encrypted"
+      def vault_attribute(attribute, options = {})
+        encrypted_column = options[:encrypted_column] || "#{attribute}_encrypted"
         path = options[:path] || "transit"
-        key = options[:key] || "#{Vault::Rails.application}_#{table_name}_#{column}"
+        key = options[:key] || "#{Vault::Rails.application}_#{table_name}_#{attribute}"
 
         # Sanity check options!
         _vault_validate_options!(options)
@@ -60,66 +60,54 @@ module Vault
         end
 
         # Getter
-        define_method(column) do
-          value = instance_variable_get(:"@#{column}")
-          return value if !value.nil?
-
-          ciphertext = read_attribute(encrypted_column)
-          plaintext  = Vault::Rails.decrypt(path, key, ciphertext)
-          plaintext  = serializer.decode(plaintext) if serializer
-
-          instance_variable_set(:"@#{column}", plaintext)
+        define_method("#{attribute}") do
+          instance_variable_get("@#{attribute}")
         end
 
         # Setter
-        define_method("#{column}=") do |plaintext|
-          plaintext = serializer.encode(plaintext) if serializer
-
-          # If we are setting the value to the same value, do nothing
-          current = instance_variable_get(:"@#{column}")
-          if current == plaintext
-            return current
+        define_method("#{attribute}=") do |value|
+          # If the currently set value is not the same as the given value (or
+          # not set at all), update the instance variable and mark it as dirty.
+          if instance_variable_get("@#{attribute}") != value
+            attribute_will_change!("#{attribute}")
+            instance_variable_set("@#{attribute}", value)
           end
 
-          attribute_will_change!(column.to_s)
-
-          ciphertext = Vault::Rails.encrypt(path, key, plaintext)
-          write_attribute(encrypted_column, ciphertext)
-
-          plaintext = serializer.decode(plaintext) if serializer
-          instance_variable_set(:"@#{column}", plaintext)
+          # Return the value to be consistent with other AR methods.
+          value
         end
 
         # Checker
-        define_method("#{column}?") do
-          read_attribute(encrypted_column).present?
+        define_method("#{attribute}?") do
+          instance_variable_get("@#{attribute}").present?
         end
 
         # Dirty method
-        define_method("#{column}_change") do
-          changes[column]
+        define_method("#{attribute}_change") do
+          changes["#{attribute}"]
         end
 
         # Dirty method
-        define_method("#{column}_changed?") do
-          changed.include?(column.to_s)
+        define_method("#{attribute}_changed?") do
+          changed.include?("#{attribute}")
         end
 
         # Dirty method
-        define_method("#{column}_was") do
-          if changes[column]
-            changes[column][0]
+        define_method("#{attribute}_was") do
+          if changes["#{attribute}"]
+            changes["#{attribute}"][0]
           else
-            public_send(column)
+            public_send("#{attribute}")
           end
         end
 
         # Make a note of this attribute so we can use it in the future (maybe).
-        _vault_attributes.store(column.to_sym,
-          encrypted_column: encrypted_column,
-          path: path,
+        __vault_attributes[attribute.to_sym] = {
           key: key,
-        )
+          path: path,
+          serializer: serializer,
+          encrypted_column: encrypted_column,
+        }
 
         self
       end
@@ -127,7 +115,7 @@ module Vault
       # The list of Vault attributes.
       #
       # @return [Hash]
-      def _vault_attributes
+      def __vault_attributes
         @vault_attributes ||= {}
       end
 
@@ -154,22 +142,96 @@ module Vault
     end
 
     included do
-      if defined?(ActiveRecord::Base)
-        # Overload ActiveRecord's `.reload` function to include resetting the
-        # instance variables for encrypted attributes. This is really only useful
-        # in tests, but one would assume that calling `.reload` on the model would
-        # reload all the things.
-        #
-        # @see ActiveRecord::Base#reload
-        alias_method :reload_without_vault_attributes, :reload
-        define_method(:reload_with_vault_attributes) do |*args, &block|
-          result = self.reload_without_vault_attributes(*args, &block)
-          self.class._vault_attributes.each do |k, _|
-            instance_variable_set(:"@#{k}", nil)
-          end
-          result
+      # After a resource has been found (since `after_initialize` does not make
+      # sense because new resources will not have Vault data), immediately
+      # communicate with Vault and decrypt the attributes (if any).
+      # after_find :__vault_load_attributes!
+      after_find :__vault_load_attributes!
+
+      # Persist any changed attributes back to Vault before saving the record.
+      before_save :__vault_persist_attributes!
+
+      # After we save the record, reload the attributes from Vault to ensure
+      # we have the proper attribute set.
+      after_save :__vault_load_attributes!
+
+      # Decrypt all the attributes from Vault.
+      # @return [true]
+      def __vault_load_attributes!
+        self.class.__vault_attributes.each do |attribute, options|
+          self.__vault_load_attribute!(attribute, options)
         end
-        alias_method :reload, :reload_with_vault_attributes
+
+        return true
+      end
+
+      # Decrypt and load a single attribute from Vault.
+      def __vault_load_attribute!(attribute, options)
+        key        = options[:key]
+        path       = options[:path]
+        serializer = options[:serializer]
+        column     = options[:encrypted_column]
+
+        # Load the ciphertext
+        ciphertext = read_attribute(column)
+
+        # Load the plaintext value
+        plaintext = Vault::Rails.decrypt(path, key, ciphertext)
+
+        # Deserialize the plaintext value, if a serializer exists
+        if serializer
+          plaintext = serializer.decode(plaintext)
+        end
+
+        # Write the virtual attribute with the plaintext value
+        instance_variable_set("@#{attribute}", plaintext)
+      end
+
+      # Encrypt all the attributes using Vault and set the encrypted values back
+      # on this model.
+      # @return [true]
+      def __vault_persist_attributes!
+        self.class.__vault_attributes.each do |attribute, options|
+          self.__vault_persist_attribute!(attribute, options)
+        end
+
+        return true
+      end
+
+      # Encrypt a single attribute using Vault and persist back onto the
+      # encrypted attribute value.
+      def __vault_persist_attribute!(attribute, options)
+        key        = options[:key]
+        path       = options[:path]
+        serializer = options[:serializer]
+        column     = options[:encrypted_column]
+
+        # Only persist changed attributes to minimize requests - this helps
+        # minimize the number of requests to Vault.
+        if !changed.include?("#{attribute}")
+          return
+        end
+
+        # Get the current value of the plaintext attribute
+        plaintext = instance_variable_get("@#{attribute}")
+
+        # Apply the serialize to the plaintext value, if one exists
+        if serializer
+          plaintext = serializer.encode(plaintext)
+        end
+
+        # Generate the ciphertext and store it back as an attribute
+        ciphertext = Vault::Rails.encrypt(path, key, plaintext)
+        write_attribute(column, ciphertext)
+      end
+
+      # Override the reload method to reload the Vault attributes. This will
+      # ensure that we always have the most recent data from Vault when we
+      # reload a record from the database.
+      def reload(*)
+        super.tap do
+          self.__vault_load_attributes!
+        end
       end
     end
   end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -18,7 +18,7 @@ class Person < ActiveRecord::Base
 
   vault_attribute :favorite_color,
     encode: ->(raw) { "xxx#{raw}xxx" },
-    decode: ->(raw) { raw[3...-3] }
+    decode: ->(raw) { raw && raw[3...-3] }
 
   vault_attribute :non_ascii
 end

--- a/spec/dummy/lib/binary_serializer.rb
+++ b/spec/dummy/lib/binary_serializer.rb
@@ -1,10 +1,12 @@
 # Encodes and decodes binary data.
 module BinarySerializer
   def self.encode(raw)
+    return raw if raw.blank?
     raw.unpack("B*")[0]
   end
 
   def self.decode(raw)
+    return raw if raw.blank?
     [raw].pack("B*")
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -48,6 +48,16 @@ describe Vault::Rails do
       expect(person.ssn).to be(nil)
     end
 
+    it "allows attributes to be unset after reload" do
+      person = Person.create!(ssn: "123-45-6789")
+      person.reload
+      person.ssn = nil
+      person.save!
+      person.reload
+
+      expect(person.ssn).to be(nil)
+    end
+
     it "allows attributes to be blank" do
       person = Person.create!(ssn: "123-45-6789")
       person.update_attributes!(ssn: "")


### PR DESCRIPTION
Prior to this commit, each interaction with a vault_attribute would issue a _new_ HTTP request to Vault and cache the result. This caused race conditions and unexpected behaviors. Additionally, it was a very poor optimization that turned out to actually be less performant that eager loading all the values from Vault at once.

This commit changes vault-rails to decrypt all values from Vault after the object is loaded, and then encrypt the values using Vault only right before the object is to be saved.

Closes https://github.com/hashicorp/vault-rails/pull/21

/cc @handlers @pearkes 