### PR TITLE
Use 'vault:v0:' prefix for in-memory encryption

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -139,7 +139,7 @@ module Vault
       cipher = OpenSSL::Cipher::AES.new(128, :CBC)
       cipher.encrypt
       cipher.key = memory_key_for(path, key)
-      return Base64.strict_encode64(cipher.update(plaintext) + cipher.final)
+      return "vault:v0:" + Base64.strict_encode64(cipher.update(plaintext) + cipher.final)
     end
 
     # Perform in-memory decryption. This is useful for testing and development.
@@ -151,6 +151,7 @@ module Vault
       cipher = OpenSSL::Cipher::AES.new(128, :CBC)
       cipher.decrypt
       cipher.key = memory_key_for(path, key)
+      ciphertext = ciphertext.gsub("vault:v0:", "")
       return cipher.update(Base64.strict_decode64(ciphertext)) + cipher.final
     end
 


### PR DESCRIPTION
This PR adds the vault prefix to ciphertexts encrypted with in-memory encryption.

This makes it possible for applications to migrate to Vault and be able to support Vault encryption through the transit backend side-by-side with their old encryption scheme. With this in place, all Vault ciphertexts will be able to be differentiated from other encrypted values by their prefix.
