### PR TITLE
Splat exceptions sent to vault client

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -208,7 +208,7 @@ module Vault
         max_wait: self.retry_max_wait,
       }
 
-      client.with_retries(exceptions, options) do |i, e|
+      client.with_retries(*exceptions, options) do |i, e|
         if !e.nil?
           log_warning "[vault-rails] (#{i}) An error occurred when trying to " \
             "communicate with Vault: #{e.message}"

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -262,4 +262,12 @@ describe Vault::Rails do
       expect(person.favorite_color).to eq("blue")
     end
   end
+
+  context 'with errors' do
+    it 'raises the appropriate exception' do
+      expect {
+        Vault::Rails.encrypt('/bogus/path', 'bogus', 'bogus')
+      }.to raise_error(Vault::HTTPClientError)
+    end
+  end
 end


### PR DESCRIPTION
The test is kind of not great but it demonstrates the problem.

Closes #36 