### PR TITLE
Add ability to lazy decrypt attributes

### DIFF
--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -1,7 +1,11 @@
 require "binary_serializer"
 
-class Person < ActiveRecord::Base
+class LazyPerson < ActiveRecord::Base
   include Vault::EncryptedModel
+
+  self.table_name = "people"
+
+  lazy_decrypt!
 
   vault_attribute :ssn
 
@@ -22,4 +26,3 @@ class Person < ActiveRecord::Base
 
   vault_attribute :non_ascii
 end
-

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -89,6 +89,99 @@ describe Vault::Rails do
     end
   end
 
+  context "lazy decrypt" do
+    before(:all) do
+      Vault::Rails.logical.write("transit/keys/dummy_people_ssn")
+    end
+
+    it "encrypts attributes" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      expect(person.ssn_encrypted).to be
+      expect(person.ssn_encrypted.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "decrypts attributes" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      person.reload
+
+      expect(person.ssn).to eq("123-45-6789")
+      expect(person.ssn.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "does not decrypt on initialization" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      person.reload
+
+      p2 = LazyPerson.find(person.id)
+
+      expect(p2.instance_variable_get("@ssn")).to eq(nil)
+      expect(p2.ssn).to eq("123-45-6789")
+    end
+
+    it "tracks dirty attributes" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+
+      expect(person.ssn_changed?).to be(false)
+      expect(person.ssn_change).to be(nil)
+      expect(person.ssn_was).to eq("123-45-6789")
+
+      person.ssn = "111-11-1111"
+
+      expect(person.ssn_changed?).to be(true)
+      expect(person.ssn_change).to eq(["123-45-6789", "111-11-1111"])
+      expect(person.ssn_was).to eq("123-45-6789")
+    end
+
+    it "allows attributes to be unset" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      person.update_attributes!(ssn: nil)
+      person.reload
+
+      expect(person.ssn).to be(nil)
+    end
+
+    it "allows saving without validations" do
+      person = LazyPerson.new(ssn: "123-456-7890")
+      expect(person.save(validate: false)).to be(true)
+      expect(person.ssn_encrypted).to match("vault:")
+    end
+
+    it "allows attributes to be unset after reload" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      person.reload
+      person.update_attributes!(ssn: nil)
+      person.reload
+
+      expect(person.ssn).to be(nil)
+    end
+
+    it "allows attributes to be blank" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      person.update_attributes!(ssn: "")
+      person.reload
+
+      expect(person.ssn).to eq("")
+    end
+
+    it "reloads instance variables on reload" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      expect(person.instance_variable_get(:@ssn)).to eq("123-45-6789")
+
+      person.ssn = "111-11-1111"
+      person.reload
+
+      expect(person.ssn).to eq("123-45-6789")
+    end
+
+    it "does not try to encrypt unchanged attributes" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+
+      expect(Vault::Rails).to_not receive(:encrypt)
+      person.name = "Cinderella"
+      person.save!
+    end
+  end
+
   context "with custom options" do
     before(:all) do
       Vault::Rails.sys.mount("credit-secrets", :transit)


### PR DESCRIPTION
This partially restores the old behavior of only decrypting
encrypted values on use. Rather than doing them one at a time though
(which would reintroduce a consistency problem), all encrypted
attributes are decrypted as soon as any encrypted attributes are
accessed.