### PR TITLE
Configurable warning messages for in-memory ciphers

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -144,7 +144,7 @@ module Vault
 
       # Perform in-memory encryption. This is useful for testing and development.
       def memory_encrypt(path, key, plaintext, client)
-        log_warning(DEV_WARNING)
+        log_warning(DEV_WARNING) if self.in_memory_warnings_enabled?
 
         return nil if plaintext.nil?
 
@@ -156,7 +156,7 @@ module Vault
 
       # Perform in-memory decryption. This is useful for testing and development.
       def memory_decrypt(path, key, ciphertext, client)
-        log_warning(DEV_WARNING)
+        log_warning(DEV_WARNING) if self.in_memory_warnings_enabled?
 
         return nil if ciphertext.nil?
 

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -25,7 +25,7 @@ module Vault
 
       # Whether the connection to Vault is enabled. The default value is `false`,
       # which means vault-rails will perform in-memory encryption/decryption and
-      # not attempt to talk to a reail Vault server. This is useful for
+      # not attempt to talk to a real Vault server. This is useful for
       # development and testing.
       #
       # @return [true, false]
@@ -47,6 +47,32 @@ module Vault
       # @return [true, false]
       def enabled=(val)
         @enabled = !!val
+      end
+
+      # Whether warnings about in-memory ciphers are enabled. The default value
+      # is `true`, which means vault-rails will log a warning for every attempt
+      # to encrypt or decrypt using an in-memory cipher. This is useful for
+      # development and testing.
+      #
+      # @return [true, false]
+      def in_memory_warnings_enabled?
+        if !defined?(@in_memory_warnings_enabled) || @in_memory_warnings_enabled.nil?
+          return true
+        end
+        return @in_memory_warnings_enabled
+      end
+
+      # Sets whether warnings about in-memory ciphers are enabled. Users can set
+      # this in an initializer depending on their Rails environment.
+      #
+      # @example
+      #   Vault.configure do |vault|
+      #     vault.in_memory_warnings_enabled = !Rails.env.test?
+      #   end
+      #
+      # @return [true, false]
+      def in_memory_warnings_enabled=(val)
+        @in_memory_warnings_enabled = val
       end
 
       # Gets the number of retry attempts.

--- a/spec/unit/rails/configurable_spec.rb
+++ b/spec/unit/rails/configurable_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe Vault::Rails::Configurable do
+  subject do
+    Class.new.tap do |c|
+      c.class.instance_eval do
+        include Vault::Rails::Configurable
+      end
+    end
+  end
+
+  describe '.in_memory_warnings_enabled?' do
+    context 'when unconfigured' do
+      it 'returns true' do
+        expect(subject.in_memory_warnings_enabled?).to eq true
+      end
+    end
+
+    context 'when configured as on' do
+      before do
+        subject.configure do |vault|
+          vault.in_memory_warnings_enabled = true
+        end
+      end
+
+      it 'returns true' do
+        expect(subject.in_memory_warnings_enabled?).to eq true
+      end
+    end
+
+    context 'when configured as off' do
+      before do
+        subject.configure do |vault|
+          vault.in_memory_warnings_enabled = false
+        end
+      end
+
+      it 'returns false' do
+        expect(subject.in_memory_warnings_enabled?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
💁  When a Rails application that uses `Vault::Rails` runs its test suite using an in-memory cipher (a common use case), this can result in many hundreds of log messages warning about using an insecure cipher in a production-like environment. This increases the logging noise and reduces the value of logging during testing. 😿 

These changes add configuration methods to disable these in-memory warnings improves the signal to noise ratio when using this gem in a test environment.

Closes #43 