### PR TITLE
CI: Support TLS v1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
+dist: trusty
 sudo: false
 
 env:


### PR DESCRIPTION
The webserver for https://releases.hashicorp.com now only supports TLS version 1.2 and above. The Travis CI build environment needs to use Trusty as the distribution in order to use OpenSSL libraries which support this version of TLS.

See: https://github.com/travis-ci/travis-ci/issues/7131