### PR TITLE
CI: Update lockfiles used for test matrix

### DIFF
--- a/gemfiles/rails_4.0.gemfile.lock
+++ b/gemfiles/rails_4.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    vault-rails (0.3.0.dev)
+    vault-rails (0.3.1)
       rails (>= 4.0)
       vault (~> 0.5)
 
@@ -129,7 +129,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    vault (0.5.0)
+    vault (0.9.0)
 
 PLATFORMS
   ruby

--- a/gemfiles/rails_4.1.gemfile.lock
+++ b/gemfiles/rails_4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    vault-rails (0.3.0.dev)
+    vault-rails (0.3.1)
       rails (>= 4.0)
       vault (~> 0.5)
 
@@ -129,7 +129,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    vault (0.5.0)
+    vault (0.9.0)
 
 PLATFORMS
   ruby

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    vault-rails (0.3.0.dev)
+    vault-rails (0.3.1)
       rails (>= 4.0)
       vault (~> 0.5)
 
@@ -129,7 +129,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    vault (0.5.0)
+    vault (0.9.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
💁  The lockfiles for the test matrix of gems has fallen out of step with the Gemfiles, causing build failures. These updates bring them back in step with the source files.