### PR TITLE
add comma before serialize in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ vault_attribute :credit_card,
 By default, all values are assumed to be "text" fields in the database. Sometimes it is beneficial for your application to work with a more flexible data structure (such as a Hash or Array). Vault-rails can automatically serialize and deserialize these structures for you:
 
 ```ruby
-vault_attribute :details
+vault_attribute :details,
   serialize: :json
 ```
 


### PR DESCRIPTION
Hi. 
I've just added the comma in README because without it I have an error
```
syntax error, unexpected ':', expecting keyword_end
    serialize: :json
```