### PR TITLE
Support convergent encryption

### DIFF
--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -20,6 +20,9 @@ class Person < ActiveRecord::Base
     encode: ->(raw) { "xxx#{raw}xxx" },
     decode: ->(raw) { raw && raw[3...-3] }
 
+  vault_attribute :first_pet,
+    convergent: true
+
   vault_attribute :non_ascii
 end
 

--- a/spec/dummy/db/migrate/20180202150631_add_first_pet_to_people.rb
+++ b/spec/dummy/db/migrate/20180202150631_add_first_pet_to_people.rb
@@ -1,0 +1,5 @@
+class AddFirstPetToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :first_pet_encrypted, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428220101) do
+ActiveRecord::Schema.define(version: 20180202150631) do
 
   create_table "people", force: :cascade do |t|
     t.string   "name"
@@ -23,6 +22,7 @@ ActiveRecord::Schema.define(version: 20150428220101) do
     t.string   "non_ascii_encrypted"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.string   "first_pet_encrypted"
   end
 
 end


### PR DESCRIPTION
Currently, Vault's Transit engine supports key derivation, but
vault-rails does not support convergent encryption.