### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ vault_attribute :address,
   decode: ->(raw) { raw.to_s }
 ```
 
-- **Note** Changing the algorithm for encoding/decoding for an existing application will probably make the application crash when attempting to retrive existing values!
+- **Note** Changing the algorithm for encoding/decoding for an existing application will probably make the application crash when attempting to retrieve existing values!
 
 Caveats
 -------

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ vault_attribute :credit_card,
 - **Note** This value **cannot** be the same name as the vault attribute!
 
 #### Specifying a custom key
-By default, the name of the key in Vault is `#{app}_#{table}_#{column}`. This is customizable by setting the `:key` coption when declaring the attribute:
+By default, the name of the key in Vault is `#{app}_#{table}_#{column}`. This is customizable by setting the `:key` option when declaring the attribute:
 
 ```ruby
 vault_attribute :credit_card,

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -112,7 +112,7 @@ module Vault
         @retry_max_wait ||= Vault::Defaults::RETRY_MAX_WAIT
       end
 
-      # Sets the naximum amount of time for a single retry. Please see the Vault
+      # Sets the maximum amount of time for a single retry. Please see the Vault
       # documentation for more information.
       #
       # @param [Fixnum] val


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`