### PR TITLE
Ruby 2.4 update for AES 128 cipher key length when running in Dev mode. 

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -150,7 +150,7 @@ module Vault
 
         cipher = OpenSSL::Cipher::AES.new(128, :CBC)
         cipher.encrypt
-        cipher.key = memory_key_for(path, key)
+        cipher.key = memory_key_for(path, key).byteslice(0, cipher.key_len)
         return Base64.strict_encode64(cipher.update(plaintext) + cipher.final)
       end
 
@@ -162,7 +162,7 @@ module Vault
 
         cipher = OpenSSL::Cipher::AES.new(128, :CBC)
         cipher.decrypt
-        cipher.key = memory_key_for(path, key)
+        cipher.key = memory_key_for(path, key).byteslice(0, cipher.key_len)
         return cipher.update(Base64.strict_decode64(ciphertext)) + cipher.final
       end
 


### PR DESCRIPTION
When doing 'in memory' encryption/decryption, you're using AES 128, the key for which needs to be restricted to the length for that specific mode. This was a change in ruby 2.4 where AES keys were no longer truncated if they were too large, and instead you get an error. 

In Rails 5.2 console, with ruby 2.5.1 I can now do: 

```
Vault.logical.write("secret/data/bacon", data: { delicious: true, cooktime: "11"})
ciphertext = Vault::Rails.encrypt('secret/data', 'bacon', 'plaintext')
 => "6fEtFKb0Rb+j02D7zJj3ug==" 
Vault::Rails.decrypt('secret/data', 'bacon', ciphertext)
 => "plaintext" 
```

Previously, the error was: 

```
ArgumentError (key must be 16 bytes)
```