### PR TITLE
Update tested Vault versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ dist: trusty
 sudo: false
 
 env:
-  - VAULT_VERSION=0.6.0
+  - VAULT_VERSION=0.9.6
+  - VAULT_VERSION=0.8.3
+  - VAULT_VERSION=0.7.3
+  - VAULT_VERSION=0.6.5
   - VAULT_VERSION=0.5.3
   - VAULT_VERSION=0.4.1
   - VAULT_VERSION=0.3.1


### PR DESCRIPTION
Updating the 0.6 version that's tested against from 0.6.0 to 0.6.5, and added in the latest 0.7, 0.8 and 0.9 releases as well.