### PR TITLE
Rails 5.2 support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise "rails-4.1" do
-  gem "rails", "~> 4.1.0"
-end if RUBY_VERSION.to_f < 2.4
-
 appraise "rails-4.2" do
   gem "rails", "~> 4.2.0"
 end
@@ -12,4 +8,8 @@ end
 
 appraise "rails-5.1" do
   gem "rails", "~> 5.1.0"
+end
+
+appraise "rails-5.2" do
+  gem "rails", "~> 5.2.0"
 end

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -63,10 +63,13 @@ module Vault
           serializer.define_singleton_method(:decode, &options[:decode])
         end
 
+        self.attribute attribute.to_s, ActiveRecord::Type::Value.new,
+          default: nil
+
         # Getter
         define_method("#{attribute}") do
           self.__vault_load_attributes! unless @__vault_loaded
-          instance_variable_get("@#{attribute}")
+          super()
         end
 
         # Setter
@@ -79,6 +82,7 @@ module Vault
 
           attribute_will_change!("#{attribute}")
           instance_variable_set("@#{attribute}", value)
+          super(value)
 
           # Return the value to be consistent with other AR methods.
           value
@@ -86,27 +90,7 @@ module Vault
 
         # Checker
         define_method("#{attribute}?") do
-          self.__vault_load_attributes! unless @__vault_loaded
-          instance_variable_get("@#{attribute}").present?
-        end
-
-        # Dirty method
-        define_method("#{attribute}_change") do
-          changes["#{attribute}"]
-        end
-
-        # Dirty method
-        define_method("#{attribute}_changed?") do
-          changed.include?("#{attribute}")
-        end
-
-        # Dirty method
-        define_method("#{attribute}_was") do
-          if changes["#{attribute}"]
-            changes["#{attribute}"][0]
-          else
-            public_send("#{attribute}")
-          end
+          public_send(attribute).present?
         end
 
         # Make a note of this attribute so we can use it in the future (maybe).
@@ -212,7 +196,7 @@ module Vault
 
         # If the user provided a value for the attribute, do not try to load
         # it from Vault
-        if instance_variable_get("@#{attribute}")
+        if attributes[attribute.to_s]
           return
         end
 
@@ -232,6 +216,7 @@ module Vault
 
         # Write the virtual attribute with the plaintext value
         instance_variable_set("@#{attribute}", plaintext)
+        @attributes.write_from_database attribute.to_s, plaintext
       end
 
       # Encrypt all the attributes using Vault and set the encrypted values back
@@ -267,12 +252,16 @@ module Vault
 
         # Only persist changed attributes to minimize requests - this helps
         # minimize the number of requests to Vault.
-        if !changed.include?("#{attribute}")
-          return
+        if ActiveRecord.gem_version >= Gem::Version.new("5.2")
+          return unless previous_changes_include?(attribute)
+        elsif ActiveRecord.gem_version >= Gem::Version.new("5.1")
+          return unless saved_change_to_attribute?(attribute.to_s)
+        else
+          return unless attribute_changed?(attribute)
         end
 
         # Get the current value of the plaintext attribute
-        plaintext = instance_variable_get("@#{attribute}")
+        plaintext = attributes[attribute.to_s]
 
         # Apply the serialize to the plaintext value, if one exists
         if serializer
@@ -319,6 +308,7 @@ module Vault
           # from Vault
           self.class.__vault_attributes.each do |attribute, _|
             self.instance_variable_set("@#{attribute}", nil)
+            @attributes.write_from_database attribute.to_s, nil
           end
 
           self.__vault_initialize_attributes!

--- a/spec/unit/encrypted_model_spec.rb
+++ b/spec/unit/encrypted_model_spec.rb
@@ -42,10 +42,9 @@ describe Vault::EncryptedModel do
     end
 
     it "defines dirty attribute methods" do
-      klass.vault_attribute(:foo)
-      expect(klass.instance_methods).to include(:foo_change)
-      expect(klass.instance_methods).to include(:foo_changed?)
-      expect(klass.instance_methods).to include(:foo_was)
+      expect(Person.new).to respond_to(:ssn_change)
+      expect(Person.new).to respond_to(:ssn_changed?)
+      expect(Person.new).to respond_to(:ssn_was)
     end
   end
 end


### PR DESCRIPTION
This is built on top of #66, but I'm just going to focus here on what's been done in 169f021adb0dcfe4e83954505de2854644610513 (and further commits after that, should there be changes):

* Instead of manually crafting dirty state support, I'm opting to use Rails' own approaches for this, which arguably makes the behaviour more reliable and consistent - even though there's now some allowances of slightly different behaviour across versions.
* The catch is that these helpers don't exist in Rails 4.1. Maybe this is a good opportunity to end 4.1 support?
* I've left in references to model instance variables (e.g. `@ssn`), given they're covered by specs - though I personally would prefer to scrap that support, which makes the code a little more simpler. They're ideally not part of any public API, I'd hope?
* The spec change is purely because the dirty state methods are lazily added to models, and so initially not available via `klass.instance_methods`. `klass` cannot be instantiated (no table exists) hence switching to use `Person` instead.