### PR TITLE
 Per-record transit key names

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,45 @@ vault_attribute :credit_card,
 - **Note** This value **cannot** be the same name as the vault attribute!
 
 #### Specifying a custom key
-By default, the name of the key in Vault is `#{app}_#{table}_#{column}`. This is customizable by setting the `:key` option when declaring the attribute:
+
+By default, the name of the key in Vault is `#{app}_#{table}_#{column}`. This is customizable by setting the `:key` option when declaring the attribute.
+
+- **Note** Changing this value for an existing application will make existing values no longer decryptable!
+
+##### String
+
+With a string, all records will use the same transit key for this attribute:
 
 ```ruby
 vault_attribute :credit_card,
   key: "pci-data"
 ```
 
-- **Note** Changing this value for an existing application will make existing values no longer decryptable!
+##### Symbol
+
+When using a symbol, a method will be called on the record to compute the key name:
+
+```ruby
+belongs_to :user
+
+vault_attribute :credit_card,
+  key: :vault_key
+
+def vault_key
+  "user_#{user.id}"
+end
+```
+
+##### Proc
+
+Given a proc, it will be called each time to compute the key name:
+
+```ruby
+belongs_to :user
+
+vault_attribute :credit_card,
+  key: ->(record) { "user_#{record.user.id}" }
+```
 
 #### Specifying a different Vault path
 By default, the path to the transit backend in Vault is `transit/`. This is customizable by setting the `:path` option when declaring the attribute:

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -25,4 +25,14 @@ class LazyPerson < ActiveRecord::Base
     decode: ->(raw) { raw && raw[3...-3] }
 
   vault_attribute :non_ascii
+
+  vault_attribute :symbol_key,
+    key: :encryption_key
+
+  vault_attribute :proc_key,
+    key: ->(record) { record.encryption_key }
+
+  def encryption_key
+    "person_#{id}"
+  end
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -21,5 +21,14 @@ class Person < ActiveRecord::Base
     decode: ->(raw) { raw && raw[3...-3] }
 
   vault_attribute :non_ascii
-end
 
+  vault_attribute :symbol_key,
+    key: :encryption_key
+
+  vault_attribute :proc_key,
+    key: ->(record) { record.encryption_key }
+
+  def encryption_key
+    "person_#{id}"
+  end
+end

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -1,4 +1,4 @@
-class CreatePeople < ActiveRecord::Migration
+class CreatePeople < ActiveRecord::Migration[4.2]
   def change
     create_table :people do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -8,6 +8,8 @@ class CreatePeople < ActiveRecord::Migration[4.2]
       t.string :business_card_encrypted
       t.string :favorite_color_encrypted
       t.string :non_ascii_encrypted
+      t.string :symbol_key_encrypted
+      t.string :proc_key_encrypted
 
       t.timestamps null: false
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,18 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428220101) do
+ActiveRecord::Schema.define(version: 2015_04_28_220101) do
 
   create_table "people", force: :cascade do |t|
-    t.string   "name"
-    t.string   "ssn_encrypted"
-    t.string   "cc_encrypted"
-    t.string   "details_encrypted"
-    t.string   "business_card_encrypted"
-    t.string   "favorite_color_encrypted"
-    t.string   "non_ascii_encrypted"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.string "name"
+    t.string "ssn_encrypted"
+    t.string "cc_encrypted"
+    t.string "details_encrypted"
+    t.string "business_card_encrypted"
+    t.string "favorite_color_encrypted"
+    t.string "non_ascii_encrypted"
+    t.string "symbol_key_encrypted"
+    t.string "proc_key_encrypted"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -180,6 +180,30 @@ describe Vault::Rails do
       person.name = "Cinderella"
       person.save!
     end
+
+    context "with a symbol key" do
+      it "encodes and decodes attributes" do
+        person = LazyPerson.create!(symbol_key: "foobar")
+        person.reload
+
+        raw = Vault::Rails.decrypt("transit", person.encryption_key, person.symbol_key_encrypted)
+        expect(raw).to eq("foobar")
+
+        expect(person.symbol_key).to eq("foobar")
+      end
+    end
+
+    context "with a proc key" do
+      it "encodes and decodes attributes" do
+        person = LazyPerson.create!(proc_key: "foobar")
+        person.reload
+
+        raw = Vault::Rails.decrypt("transit", person.encryption_key, person.proc_key_encrypted)
+        expect(raw).to eq("foobar")
+
+        expect(person.proc_key).to eq("foobar")
+      end
+    end
   end
 
   context "with custom options" do
@@ -353,6 +377,30 @@ describe Vault::Rails do
       expect(raw).to eq("xxxbluexxx")
 
       expect(person.favorite_color).to eq("blue")
+    end
+  end
+
+  context "with a symbol key" do
+    it "encodes and decodes attributes" do
+      person = Person.create!(symbol_key: "foobar")
+      person.reload
+
+      raw = Vault::Rails.decrypt("transit", person.encryption_key, person.symbol_key_encrypted)
+      expect(raw).to eq("foobar")
+
+      expect(person.symbol_key).to eq("foobar")
+    end
+  end
+
+  context "with a proc key" do
+    it "encodes and decodes attributes" do
+      person = Person.create!(proc_key: "foobar")
+      person.reload
+
+      raw = Vault::Rails.decrypt("transit", person.encryption_key, person.proc_key_encrypted)
+      expect(raw).to eq("foobar")
+
+      expect(person.proc_key).to eq("foobar")
     end
   end
 


### PR DESCRIPTION
This adds support for dynamically computing a transit key name on each encrypt/decrypt request, which allows an application to use a separate key per record, or using an encryption key per belongs_to relation.