### PR TITLE
Add support for key derivation with a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,51 @@ vault_attribute :credit_card,
 
 - **Note** Changing this value for an existing application will make existing values no longer decryptable!
 
+#### Specifying a context (key derivation)
+
+Vault Transit supports key derivation, which allows the same key to be used for multiple purposes by deriving a new key based on a context value.
+
+The context can be specified as a string, symbol, or proc. Symbols (an instance method on the model) and procs are called for each encryption or decryption request, and should return a string.
+
+- **Note** Changing the context or context generator for an attribute will make existing values no longer decryptable!
+
+##### String
+
+With a string, all records will use the same context for this attribute:
+
+```ruby
+vault_attribute :credit_card,
+  context: "user-cc"
+```
+
+##### Symbol
+
+When using a symbol, a method will be called on the record to compute the context:
+
+```ruby
+belongs_to :user
+
+vault_attribute :credit_card,
+  context: :encryption_context
+
+def encryption_context
+  "user_#{user.id}"
+end
+```
+
+##### Proc
+
+Given a proc, it will be called each time to compute the context:
+
+```ruby
+belongs_to :user
+
+vault_attribute :credit_card,
+  context: ->(record) { "user_#{record.user.id}" }
+```
+
+The proc must take a single argument for the record.
+
 #### Specifying a different Vault path
 By default, the path to the transit backend in Vault is `transit/`. This is customizable by setting the `:path` option when declaring the attribute:
 

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -25,4 +25,14 @@ class LazyPerson < ActiveRecord::Base
     decode: ->(raw) { raw && raw[3...-3] }
 
   vault_attribute :non_ascii
+
+  vault_attribute :context_symbol,
+    context: :encryption_context
+
+  vault_attribute :context_proc,
+    context: ->(record) { record.encryption_context }
+
+  def encryption_context
+    "user_#{id}"
+  end
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -21,5 +21,18 @@ class Person < ActiveRecord::Base
     decode: ->(raw) { raw && raw[3...-3] }
 
   vault_attribute :non_ascii
+
+  vault_attribute :context_string,
+    context: "production"
+
+  vault_attribute :context_symbol,
+    context: :encryption_context
+
+  vault_attribute :context_proc,
+    context: ->(record) { record.encryption_context }
+
+  def encryption_context
+    "user_#{id}"
+  end
 end
 

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -1,4 +1,4 @@
-class CreatePeople < ActiveRecord::Migration
+class CreatePeople < ActiveRecord::Migration[4.2]
   def change
     create_table :people do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -8,6 +8,9 @@ class CreatePeople < ActiveRecord::Migration[4.2]
       t.string :business_card_encrypted
       t.string :favorite_color_encrypted
       t.string :non_ascii_encrypted
+      t.string :context_string_encrypted
+      t.string :context_symbol_encrypted
+      t.string :context_proc_encrypted
 
       t.timestamps null: false
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,18 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428220101) do
+ActiveRecord::Schema.define(version: 2015_04_28_220101) do
 
   create_table "people", force: :cascade do |t|
-    t.string   "name"
-    t.string   "ssn_encrypted"
-    t.string   "cc_encrypted"
-    t.string   "details_encrypted"
-    t.string   "business_card_encrypted"
-    t.string   "favorite_color_encrypted"
-    t.string   "non_ascii_encrypted"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.string "name"
+    t.string "ssn_encrypted"
+    t.string "cc_encrypted"
+    t.string "details_encrypted"
+    t.string "business_card_encrypted"
+    t.string "favorite_color_encrypted"
+    t.string "non_ascii_encrypted"
+    t.string "context_string_encrypted"
+    t.string "context_symbol_encrypted"
+    t.string "context_proc_encrypted"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -366,6 +366,89 @@ describe Vault::Rails do
     end
   end
 
+  context "with context" do
+    it "encodes and decodes with a string context" do
+      person = Person.create!(context_string: "foobar")
+      person.reload
+
+      raw = Vault::Rails.decrypt(
+        "transit", "dummy_people_context_string",
+        person.context_string_encrypted, context: "production")
+
+      expect(raw).to eq("foobar")
+
+      expect(person.context_string).to eq("foobar")
+
+      # Decrypting without the correct context fails
+      expect {
+        Vault::Rails.decrypt(
+          "transit", "dummy_people_context_string",
+          person.context_string_encrypted, context: "wrongcontext")
+      }.to raise_error(Vault::HTTPClientError, /invalid ciphertext/)
+
+      # Decrypting without a context fails
+      expect {
+        Vault::Rails.decrypt(
+          "transit", "dummy_people_context_string",
+          person.context_string_encrypted)
+      }.to raise_error(Vault::HTTPClientError, /context/)
+    end
+
+    it "encodes and decodes with a symbol context" do
+      person = Person.create!(context_symbol: "foobar")
+      person.reload
+
+      raw = Vault::Rails.decrypt(
+        "transit", "dummy_people_context_symbol",
+        person.context_symbol_encrypted, context: person.encryption_context)
+
+      expect(raw).to eq("foobar")
+
+      expect(person.context_symbol).to eq("foobar")
+
+      # Decrypting without the correct context fails
+      expect {
+        Vault::Rails.decrypt(
+          "transit", "dummy_people_context_symbol",
+          person.context_symbol_encrypted, context: "wrongcontext")
+      }.to raise_error(Vault::HTTPClientError, /invalid ciphertext/)
+
+      # Decrypting without a context fails
+      expect {
+        Vault::Rails.decrypt(
+          "transit", "dummy_people_context_symbol",
+          person.context_symbol_encrypted)
+      }.to raise_error(Vault::HTTPClientError, /context/)
+    end
+
+    it "encodes and decodes with a proc context" do
+      person = Person.create!(context_proc: "foobar")
+      person.reload
+
+      raw = Vault::Rails.decrypt(
+        "transit", "dummy_people_context_proc",
+        person.context_proc_encrypted, context: person.encryption_context)
+
+      expect(raw).to eq("foobar")
+
+      expect(person.context_proc).to eq("foobar")
+
+      # Decrypting without the correct context fails
+      expect {
+        Vault::Rails.decrypt(
+          "transit", "dummy_people_context_proc",
+          person.context_proc_encrypted, context: "wrongcontext")
+      }.to raise_error(Vault::HTTPClientError, /invalid ciphertext/)
+
+      # Decrypting without a context fails
+      expect {
+        Vault::Rails.decrypt(
+          "transit", "dummy_people_context_proc",
+          person.context_proc_encrypted)
+      }.to raise_error(Vault::HTTPClientError, /context/)
+    end
+  end
+
   context 'with errors' do
     it 'raises the appropriate exception' do
       expect {

--- a/spec/unit/encrypted_model_spec.rb
+++ b/spec/unit/encrypted_model_spec.rb
@@ -20,6 +20,12 @@ describe Vault::EncryptedModel do
       }.to raise_error(Vault::Rails::ValidationFailedError)
     end
 
+    it "raises an exception if a proc is passed to :context without an arity of 1" do
+      expect {
+        klass.vault_attribute(:foo, context: ->() { })
+      }.to raise_error(Vault::Rails::ValidationFailedError, /1 argument/i)
+    end
+
     it "defines a getter" do
       klass.vault_attribute(:foo)
       expect(klass.instance_methods).to include(:foo)


### PR DESCRIPTION
This adds support for passing a context to Vault Transit encrypt/decrypt operations, allowing an application to specify a context per record or a `belongs_to` relation (such as a user, team, or organization). The context can be a string, or if given a proc or symbol, will generate the context for each encrypt/decrypt request.

This changes the signature of `Vault::Rails.encrypt` and `Vault::Rails.decrypt`. Each had an arity of 3-4, and they now have an arity of 3 and 2 optional keyword arguments. The minor version number should be bumped on release (since the major version is still 0).