### PR TITLE
Use a digest to generate a memory key

### DIFF
--- a/spec/unit/vault/rails_spec.rb
+++ b/spec/unit/vault/rails_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe Vault::Rails do
+  describe "#memory_key_for" do
+    input_examples = [
+      ["path", "key"],
+      ["path", "key", "context"],
+      ["a_really_long_path", "a_really_long_key"],
+      ["a_really_long_path", "a_really_long_key", "a_really_long_context"],
+    ]
+
+    input_examples.each do |path, key, encryption_context|
+      context "with path=#{path}, key=#{key}, context=#{encryption_context}" do
+        it "returns exactly 16 bytes as required by OpenSSL AES 128" do
+          memory_key = Vault::Rails.send(
+            :memory_key_for, path, key, context: encryption_context
+          )
+          expect(memory_key.bytesize).to eq(16)
+        end
+      end
+    end
+
+    it "returns unique keys for different paths, keys, and contexts" do
+      memory_keys = input_examples.map { |path, key, encryption_context|
+        Vault::Rails.send(
+          :memory_key_for, path, key, context: encryption_context
+        )
+      }
+
+      expect(memory_keys).to match_array(memory_keys.uniq)
+    end
+  end
+end


### PR DESCRIPTION
The Ruby OpenSSL AES 128 cipher requires a 16-byte key. The previous implementation of #memory_key_for generated a base64 string and then truncated it to 16 bytes. This could cause longer paths/keys (and now contexts) to have the same memory key for different values.

This change uses an MD5 digest to generate a mostly-unique key for different key/path/context inputs.