### PR TITLE
Add default option to vault_attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,21 @@ vault_attribute :credit_card,
 
 The proc must take a single argument for the record.
 
+#### Specifying a default value
+
+An attribute can specify a default value, which will be set on initialization (`.new`) or after loading the value from the database. The default will be set if the value is `nil`.
+
+```ruby
+vault_attribute :access_level,
+  default: "readonly"
+
+vault_attribute :metadata,
+  serialize: :json,
+  default: {}
+```
+
 #### Specifying a different Vault path
+
 By default, the path to the transit backend in Vault is `transit/`. This is customizable by setting the `:path` option when declaring the attribute:
 
 ```ruby

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -26,6 +26,16 @@ class LazyPerson < ActiveRecord::Base
 
   vault_attribute :non_ascii
 
+  vault_attribute :default,
+    default: "abc123"
+
+  vault_attribute :default_with_serializer,
+    serialize: :json,
+    default: {}
+
+  vault_attribute :context_string,
+    context: "production"
+
   vault_attribute :context_symbol,
     context: :encryption_context
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -22,6 +22,13 @@ class Person < ActiveRecord::Base
 
   vault_attribute :non_ascii
 
+  vault_attribute :default,
+    default: "abc123"
+
+  vault_attribute :default_with_serializer,
+    serialize: :json,
+    default: {}
+
   vault_attribute :context_string,
     context: "production"
 
@@ -35,4 +42,3 @@ class Person < ActiveRecord::Base
     "user_#{id}"
   end
 end
-

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -8,6 +8,8 @@ class CreatePeople < ActiveRecord::Migration[4.2]
       t.string :business_card_encrypted
       t.string :favorite_color_encrypted
       t.string :non_ascii_encrypted
+      t.string :default_encrypted
+      t.string :default_with_serializer_encrypted
       t.string :context_string_encrypted
       t.string :context_symbol_encrypted
       t.string :context_proc_encrypted

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2015_04_28_220101) do
     t.string "business_card_encrypted"
     t.string "favorite_color_encrypted"
     t.string "non_ascii_encrypted"
+    t.string "default_encrypted"
+    t.string "default_with_serializer_encrypted"
     t.string "context_string_encrypted"
     t.string "context_symbol_encrypted"
     t.string "context_proc_encrypted"

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -294,9 +294,73 @@ describe Vault::Rails do
     end
   end
 
+  context "with a default" do
+    %i[new create].each do |creation_method|
+      context "on #{creation_method}" do
+        context "without an initial attribute" do
+          it "sets the default" do
+            person = Person.public_send(creation_method)
+            expect(person.default).to eq("abc123")
+            person.save!
+            person.reload
+            expect(person.default).to eq("abc123")
+          end
+        end
+
+        context "with an initial attribute" do
+          it "does not set the default" do
+            person = Person.public_send(creation_method, default: "another")
+            expect(person.default).to eq("another")
+            person.save!
+            person.reload
+            expect(person.default).to eq("another")
+          end
+        end
+      end
+    end
+  end
+
+  context "with a default and serializer" do
+    %i[new create].each do |creation_method|
+      context "on #{creation_method}" do
+        context "without an initial attribute" do
+          it "sets the default" do
+            person = Person.public_send(creation_method)
+            expect(person.default_with_serializer).to eq({})
+            person.save!
+            person.reload
+            expect(person.default_with_serializer).to eq({})
+          end
+        end
+
+        context "with an initial attribute" do
+          it "does not set the default" do
+            person = Person.public_send(
+              creation_method,
+              default_with_serializer: { "foo" => "bar" }
+            )
+
+            expect(person.default_with_serializer).to eq({ "foo" => "bar" })
+            person.save!
+            person.reload
+            expect(person.default_with_serializer).to eq({ "foo" => "bar" })
+          end
+        end
+      end
+    end
+  end
+
   context "with the :json serializer"  do
     before(:all) do
       Vault::Rails.logical.write("transit/keys/dummy_people_details")
+    end
+
+    it "does not default to a hash" do
+      person = Person.new
+      expect(person.details).to eq(nil)
+      person.save!
+      person.reload
+      expect(person.details).to eq(nil)
     end
 
     it "tracks dirty attributes" do


### PR DESCRIPTION
This adds a `:default` option to `vault_attribute`, allowing a default value to be set if the underlying value is `nil`.

```rb
vault_attribute :metadata,
  serializer: :json,
  default: {}

vault_attribute :access_level,
  default: "readonly"
```

This enables a simple fix for applications affected by the breaking change introduced in #81 for `serialize: :json` empty values.