### PR TITLE
Require a default with the built-in serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ vault_attribute :metadata,
   default: {}
 ```
 
+Defaults are required when using a serializer.
+
 #### Specifying a different Vault path
 
 By default, the path to the transit backend in Vault is `transit/`. This is customizable by setting the `:path` option when declaring the attribute:
@@ -192,11 +194,17 @@ person.ssn # Vault communication happens here
 ```
 
 #### Automatic serializing
-By default, all values are assumed to be "text" fields in the database. Sometimes it is beneficial for your application to work with a more flexible data structure (such as a Hash or Array). Vault-rails can automatically serialize and deserialize these structures for you:
+
+By default, all values are assumed to be "text" fields in the database. Sometimes it is beneficial for your application to work with a more flexible data structure (such as a Hash or Array). Vault-rails can automatically serialize and deserialize these structures for you. Use of a built-in serializer requires that a `:default` be set,
 
 ```ruby
 vault_attribute :details,
-  serialize: :json
+  serialize: :json,
+  default: {}
+
+vault_attribute :configuration,
+  serialize: :json,
+  default: nil
 ```
 
 - **Note** You can view the source for the exact serialization and deserialization options, but they are intentionally not customizable and cannot be used for a full object marshal/unmarshal.
@@ -219,7 +227,8 @@ Your class must account for `nil` and "empty" values if necessary. Then specify 
 
 ```ruby
 vault_attribute :details,
-  serialize: MySerializer
+  serialize: MySerializer,
+  default: {}
 ```
 
 - **Note** It is possible to encode and decode entire Ruby objects using a custom serializer. Please do not do that. You will have a bad time.

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -136,7 +136,12 @@ module Vault
       # Validate that Vault options are all a-okay! This method will raise
       # exceptions if something does not make sense.
       def _vault_validate_options!(options)
-        if options[:serializer]
+        if serializer = options[:serializer]
+          if serializer.is_a?(Symbol) && !options.has_key?(:default)
+            raise Vault::Rails::ValidationFailedError, "Use of a built-in " \
+              "serializer requires a `:default` to be set!"
+          end
+
           if options[:encode] || options[:decode]
             raise Vault::Rails::ValidationFailedError, "Cannot use a " \
               "custom encoder/decoder if a `:serializer' is specified!"

--- a/spec/unit/encrypted_model_spec.rb
+++ b/spec/unit/encrypted_model_spec.rb
@@ -10,20 +10,46 @@ describe Vault::EncryptedModel do
   describe ".vault_attribute" do
     it "raises an exception if a serializer and :encode is given" do
       expect {
-        klass.vault_attribute(:foo, serializer: :json, encode: ->(r) { r })
-      }.to raise_error(Vault::Rails::ValidationFailedError)
+        klass.vault_attribute :foo,
+          serializer: :json,
+          default: {},
+          encode: ->(r) { r }
+      }.to raise_error(
+        Vault::Rails::ValidationFailedError,
+        %r{cannot use a custom encoder/decoder}i
+      )
     end
 
     it "raises an exception if a serializer and :decode is given" do
       expect {
-        klass.vault_attribute(:foo, serializer: :json, decode: ->(r) { r })
-      }.to raise_error(Vault::Rails::ValidationFailedError)
+        klass.vault_attribute :foo,
+          serializer: :json,
+          default: {},
+          decode: ->(r) { r }
+      }.to raise_error(
+        Vault::Rails::ValidationFailedError,
+        %r{cannot use a custom encoder/decoder}i
+      )
     end
 
     it "raises an exception if a proc is passed to :context without an arity of 1" do
       expect {
-        klass.vault_attribute(:foo, context: ->() { })
-      }.to raise_error(Vault::Rails::ValidationFailedError, /1 argument/i)
+        klass.vault_attribute :foo,
+          context: ->() { }
+      }.to raise_error(
+        Vault::Rails::ValidationFailedError,
+        %r{must take 1 argument}i
+      )
+    end
+
+    it "raises an exception if a serializer is given without a :default" do
+      expect {
+        klass.vault_attribute :foo,
+          serializer: :json
+      }.to raise_error(
+        Vault::Rails::ValidationFailedError,
+        %r{use of a built-in serializer requires}i
+      )
     end
 
     it "defines a getter" do


### PR DESCRIPTION
When upgrading from v0.4.0, the following attribute would have previously returned an empty hash (`{}`) would now return `nil` for new values.

```rb
vault_attribute :data,
  serialize: :json
```

In the changelog, we'll call out that this should have a default added with `{}` to preserve legacy behavior, like so:

```rb
vault_attribute :data,
  serialize: :json,
  default: {}
```

This PR proposes to make the default a requirement for using built-in serializers (of which only :json exists). This would make it more apparent during local development and test runs that the default must be added to existing serialized vault_attributes, via an error being raised at model load time.

The downside of this change is that for attributes that do not require a default, a default must still be passed:

```rb
vault_attribute :data,
  serialize: :json,
  default: nil
```

But perhaps requiring the user to be explicit is better than implicit in this case.