### PR TITLE
Store ciphertext with a prefix in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Quick Start
       # disabled, vault-rails will encrypt data in-memory using a similar
       # algorithm to Vault. The in-memory store uses a predictable encryption
       # which is great for development and test, but should _never_ be used in
-      # production.
+      # production. Default: ENV["VAULT_RAILS_ENABLED"].
       vault.enabled = Rails.env.production?
 
       # The name of the application. All encrypted keys in Vault will be
       # prefixed with this application name. If you change the name of the
       # application, you will need to migrate the encrypted data to the new
-      # key namespace.
+      # key namespace. Default: ENV["VAULT_RAILS_APPLICATION"].
       vault.application = "my_app"
 
       # The address of the Vault server. Default: ENV["VAULT_ADDR"].

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -10,10 +10,13 @@ module Vault
       #
       # @return [String]
       def application
-        if !defined?(@application) || @application.nil?
-          raise RuntimeError, "Must set `Vault::Rails#application'!"
+        if defined?(@application) && !@application.nil?
+          return @application
         end
-        return @application
+        if ENV.has_key?("VAULT_RAILS_APPLICATION")
+          return ENV["VAULT_RAILS_APPLICATION"]
+        end
+        raise RuntimeError, "Must set `Vault::Rails#application'!"
       end
 
       # Set the name of the application.
@@ -30,10 +33,13 @@ module Vault
       #
       # @return [true, false]
       def enabled?
-        if !defined?(@enabled) || @enabled.nil?
-          return false
+        if defined?(@enabled) && !@enabled.nil?
+          return @enabled
         end
-        return @enabled
+        if ENV.has_key?("VAULT_RAILS_ENABLED")
+          return (ENV["VAULT_RAILS_ENABLED"] == "true")
+        end
+        return false
       end
 
       # Sets whether Vault is enabled. Users can set this in an initializer

--- a/lib/vault/rails/errors.rb
+++ b/lib/vault/rails/errors.rb
@@ -14,6 +14,14 @@ module Vault
       end
     end
 
+    class InvalidCiphertext < VaultRailsError
+      def initialize(ciphertext)
+        super <<~EOH
+          Invalid ciphertext: `#{ciphertext}'.
+        EOH
+      end
+    end
+
     class ValidationFailedError < VaultRailsError; end
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -510,4 +510,19 @@ describe Vault::Rails do
       }.to raise_error(Vault::HTTPClientError)
     end
   end
+
+  context "without a server" do
+    it "encrypts attributes with a dev prefix" do
+      allow(Vault::Rails).to receive(:enabled?).and_return(false)
+      person = Person.create!(credit_card: "1234567890111213")
+      expect(person.cc_encrypted).to start_with(Vault::Rails::DEV_PREFIX)
+    end
+
+    it "decrypts attributes" do
+      allow(Vault::Rails).to receive(:enabled?).and_return(false)
+      person = Person.create!(credit_card: "1234567890111213")
+      person.reload
+      expect(person.credit_card).to eq("1234567890111213")
+    end
+  end
 end

--- a/spec/unit/rails/configurable_spec.rb
+++ b/spec/unit/rails/configurable_spec.rb
@@ -9,6 +9,81 @@ describe Vault::Rails::Configurable do
     end
   end
 
+  describe '.application' do
+    context 'when unconfigured' do
+      it 'raises exception' do
+        expect {
+          subject.application
+        }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when configured' do
+      before do
+        subject.configure do |vault|
+          vault.application = "dummy"
+        end
+      end
+
+      it 'returns the application' do
+        expect(subject.application).to eq "dummy"
+      end
+    end
+
+    context 'falls back to ENV' do
+      before do
+        ENV["VAULT_RAILS_APPLICATION"] = "envdummy"
+      end
+      after do
+        ENV.delete("VAULT_RAILS_APPLICATION")
+      end
+
+      it 'returns the application defined in ENV' do
+        expect(subject.application).to eq "envdummy"
+      end
+    end
+  end
+
+  describe '.enabled' do
+    context 'when unconfigured' do
+      it 'returns false' do
+        expect(subject.enabled?).to eq false
+      end
+    end
+
+    context 'when configured' do
+      it 'returns true' do
+        subject.configure do |vault|
+          vault.enabled = true
+        end
+        expect(subject.enabled?).to eq true
+      end
+
+      it 'returns false' do
+        subject.configure do |vault|
+          vault.enabled = false
+        end
+        expect(subject.enabled?).to eq false
+      end
+    end
+
+    context 'falls back to ENV' do
+      after do
+        ENV.delete("VAULT_RAILS_ENABLED")
+      end
+
+      it 'returns false' do
+        ENV["VAULT_RAILS_ENABLED"] = "false"
+        expect(subject.enabled?).to eq false
+      end
+
+      it 'returns true' do
+        ENV["VAULT_RAILS_ENABLED"] = "true"
+        expect(subject.enabled?).to eq true
+      end
+    end
+  end
+
   describe '.in_memory_warnings_enabled?' do
     context 'when unconfigured' do
       it 'returns true' do


### PR DESCRIPTION
Store ciphertext with a prefix in dev mode, similar to real vault.

I have an app with validations and I check that the ciphertext starts with `vault:`, but I can't have this check on in development mode unfortunately. With this change, I can simplify my validation and always have it on.

Please let me know if you want any changes. Thanks!