### PR TITLE
Introduce vault_single_decrypt flag to only load the attribute we car…

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ vault_attribute :credit_card,
 - **Note** Changing this value for an existing application will make existing values no longer decryptable!
 
 #### Lazy attribute decryption
-By default, `vault-rails` will decrypt a record’s encrypted attributes on that record’s initializarion. You can configure an encrypted model to decrypt attributes lazily, which will prevent communication with Vault until an encrypted attribute’s getter method is called, at which point all of the record’s encrypted attributes will be decrypted. This is useful if you do not always need access to encrypted attributes. For example:
+By default, `vault-rails` will decrypt a record’s encrypted attributes on that record’s initialization. You can configure an encrypted model to decrypt attributes lazily, which will prevent communication with Vault until an encrypted attribute’s getter method is called, at which point all of the record’s encrypted attributes will be decrypted. This is useful if you do not always need access to encrypted attributes. For example:
 
 
 ```ruby
@@ -189,6 +189,33 @@ person.ssn
 person = Person.find(id)
 person.ssn # Vault communication happens here
 # => "123-45-6789"
+```
+
+#### Single, lazy attribute decryption
+By default, `vault-rails` will decrypt all encrypted attributes on that record’s initialization on a class by class basis. You can configure an encrypted model to decrypt attributes lazily and and individually. This will prevent vault from loading all vault_attributes defined on a class the moment one attribute is requested.
+
+
+```ruby
+class Person < ActiveRecord::Base
+  include Vault::EncryptedModel
+  vault_lazy_decrypt!
+  vault_single_decrypt!
+
+  vault_attribute :ssn
+  vault_attribute :email
+end
+
+# Without vault_single_decrypt:
+person = Person.find(id) # Vault communication happens here
+person.ssn # Vault communication happens here, fetches both ssn and email
+# => "123-45-6789"
+
+# With vault_single_decrypt:
+person = Person.find(id)
+person.ssn # Vault communication happens here, fetches only ssn
+# => "123-45-6789"
+person.email # Vault communication happens here, fetches only email
+# => "foobar@baz.com"
 ```
 
 #### Serialization

--- a/spec/dummy/app/models/lazy_single_person.rb
+++ b/spec/dummy/app/models/lazy_single_person.rb
@@ -1,0 +1,18 @@
+
+class LazySinglePerson < ActiveRecord::Base
+  include Vault::EncryptedModel
+
+  self.table_name = "people"
+
+  vault_lazy_decrypt!
+  vault_single_decrypt!
+
+  vault_attribute :ssn
+
+  vault_attribute :credit_card,
+    encrypted_column: :cc_encrypted
+
+  def encryption_context
+    "user_#{id}"
+  end
+end


### PR DESCRIPTION
…e about


In a class with multiple vault attributes defined, the moment one attribute is loaded, all vault attributes are loaded.

This becomes hard in terms of telemetry and operations to maintain. Adding read / write alarms in application code will often measure latencies of all attribute gets, and failures of the first failing operation.

This PR separates out this concern by only loading the attribute that is under GET / SET scrutiny.