### PR TITLE
Adding Rails 6.0+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ branches:
     - master
 
 rvm:
-  - "2.4"
   - "2.5"
   - "2.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
   - bundle exec rake app:db:create
   - bundle exec rake app:db:schema:load
   - bundle exec rake app:db:test:prepare
+  - gem uninstall sqlite3
   - bundle exec appraisal install
 
 script: bundle exec appraisal rake

--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,24 @@
 appraise "rails-4.2" do
   gem "rails", "~> 4.2.0"
+  gem "sqlite3", "~> 1.3.0"
 end
 
 appraise "rails-5.0" do
   gem "rails", "~> 5.0.0"
+  gem "sqlite3", "~> 1.3.0"
 end
 
 appraise "rails-5.1" do
   gem "rails", "~> 5.1.0"
+  gem "sqlite3", "~> 1.3.0"
 end
 
 appraise "rails-5.2" do
   gem "rails", "~> 5.2.0"
+  gem "sqlite3", "~> 1.3.0"
+end
+
+appraise "rails-6.0" do
+  gem "rails", "~> 6.0.0"
+  gem "sqlite3", "~> 1.4.0"
 end

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -263,7 +263,9 @@ module Vault
 
         # Only persist changed attributes to minimize requests - this helps
         # minimize the number of requests to Vault.
-        if ActiveRecord.gem_version >= Gem::Version.new("5.2")
+        if ActiveRecord.gem_version >= Gem::Version.new("6.0")
+          return unless previous_changes.include?(attribute)
+        elsif ActiveRecord.gem_version >= Gem::Version.new("5.2")
           return unless previous_changes_include?(attribute)
         elsif ActiveRecord.gem_version >= Gem::Version.new("5.1")
           return unless saved_change_to_attribute?(attribute.to_s)

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rake",    "~> 10.0"
   s.add_development_dependency "rspec",   "~> 3.2"
-  s.add_development_dependency "sqlite3", "~> 1.3.0"
+  s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
## Description
This is a pretty simple change to support changes made in Rails 6.0, most notably removing the `previous_changes_include?` method.

This also goes through and removes sqlite3 being locked at 1.3.x