### PR TITLE
Add Transform Secrets engine support

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -133,15 +133,8 @@ module Vault
         end
         if transform_opts = options[:transform_secret]
           if !transform_opts[:transformation]
-            if !transform_opts[:type] && !transform_opts[:template]
-              raise Vault::Rails::ValidationFailedError, "Option " \
-                "`:transform_secret' must be supplied with either a " \
-                "`:transformation' option or a `:type' and `:template!"
-            elsif (transform_opts[:type] && !transform_opts[:template]) ||
-                  (!transform_opts[:type] && transform_opts[:template])
-              raise Vault::Rails::VaildationFailedError, "Transform Secrets " \
-                "requires both a `:type' and a `:template'!"
-            end
+            raise Vault::Rails::VaildationFailedError, "Transform Secrets " \
+              "requires a transformation name!"
           end
         end
       end

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -43,8 +43,8 @@ module Vault
       # @option options [Proc] :decode
       #   a proc to decode the value with
       # @option options [Hash] :transform_secret
-      #   a hash providing details about a transformation to use,
-      #   or a name of an existing transformation
+      #   a hash providing details about the transformation to use,
+      #   this includes the name, and the role to use
       def vault_attribute(attribute, options = {})
         # Sanity check options!
         _vault_validate_options!(options)

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -42,7 +42,7 @@ module Vault
       #   a proc to encode the value with
       # @option options [Proc] :decode
       #   a proc to decode the value with
-      # @option options [Hash, String] :transform_secret
+      # @option options [Hash] :transform_secret
       #   a hash providing details about a transformation to use,
       #   or a name of an existing transformation
       def vault_attribute(attribute, options = {})
@@ -265,6 +265,9 @@ module Vault
         generated_context = __vault_generate_context(context)
 
         if transform
+          # If this is a secret encrypted with FPE, we do not need to decrypt with vault
+          # This prevents a double encryption via standard vault encryption and FPE.
+          # FPE is decrypted later as part of the serializer
           plaintext = ciphertext
         else
           # Load the plaintext value
@@ -345,6 +348,9 @@ module Vault
         generated_context = __vault_generate_context(context)
 
         if transform
+          # If this is a secret encrypted with FPE, we should not encrypt it in vault
+          # This prevents a double encryption via standard vault encryption and FPE.
+          # FPE was performed earlier as part of the serialization process.
           ciphertext = plaintext
         else
           # Generate the ciphertext and store it back as an attribute

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -1,3 +1,4 @@
+require "pry"
 require "active_support/concern"
 
 module Vault
@@ -53,6 +54,7 @@ module Vault
                       else
                         parse_transit_attributes(attribute, options)
                       end
+        parsed_opts[:encrypted_column] = options[:encrypted_column] || "#{attribute}_encrypted"
 
         # Make a note of this attribute so we can use it in the future (maybe).
         __vault_attributes[attribute.to_sym] = parsed_opts
@@ -165,7 +167,6 @@ module Vault
       def parse_transform_secret_attributes(attribute, options)
         opts = {}
         opts[:transform_secret] = true
-        opts[:encrypted_column] = options[:encrypted_column] || "#{attribute}"
 
         serializer = Class.new
         serializer.define_singleton_method(:encode) do |raw|
@@ -184,7 +185,6 @@ module Vault
 
       def parse_transit_attributes(attribute, options)
         opts = {}
-        opts[:encrypted_column] = options[:encrypted_column] || "#{attribute}_encrypted"
         opts[:path] = options[:path] || "transit"
         opts[:key] = options[:key] || "#{Vault::Rails.application}_#{table_name}_#{attribute}"
         opts[:context] = options[:context]

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -273,7 +273,7 @@ module Vault
       end
 
       def transform_role_name(opts)
-        opts[:role_name] || self.default_role_name || self.application
+        opts[:role] || self.default_role_name || self.application
       end
     end
   end

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -141,6 +141,34 @@ module Vault
         end
       end
 
+      def transform_encode(plaintext, opts={})
+        return plaintext if plaintext&.empty?
+        request_opts = {}
+        request_opts[:value] = plaintext
+
+        if opts[:transformation]
+          request_opts[:transformation] = opts[:transformation]
+        end
+
+        role_name = transform_role_name(opts)
+        client.transform.encode(role_name: role_name, **request_opts)
+      end
+
+      def transform_decode(ciphertext, opts={})
+        return ciphertext if ciphertext&.empty?
+        request_opts = {}
+        request_opts[:value] = ciphertext
+
+        if opts[:transformation]
+          request_opts[:transformation] = opts[:transformation]
+        end
+
+        role_name = transform_role_name(opts)
+        puts request_opts
+        client.transform.decode(role_name: role_name, **request_opts)
+      end
+
+
       protected
 
       # Perform in-memory encryption. This is useful for testing and development.
@@ -242,6 +270,10 @@ module Vault
         if defined?(::Rails) && ::Rails.logger != nil
           ::Rails.logger.warn { msg }
         end
+      end
+
+      def transform_role_name(opts)
+        opts[:role_name] || self.default_role_name || self.application
       end
     end
   end

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -125,6 +125,20 @@ module Vault
       def retry_max_wait=(val)
         @retry_max_wait = val
       end
+
+      # Gets the default role name.
+      #
+      # @return [String]
+      def default_role_name
+        @default_role_name
+      end
+
+      # Sets the default role to use with various plugins.
+      #
+      # @param [String] val
+      def default_role_name=(val)
+        @default_role_name = val
+      end
     end
   end
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -39,9 +39,19 @@ class Person < ActiveRecord::Base
     context: ->(record) { record.encryption_context }
 
   vault_attribute :transform_ssn,
-    encrypted_column: :transform_ssn,
     transform_secret: {
       transformation: "social_sec"
+    }
+
+  vault_attribute :bad_transform,
+    transform_secret: {
+      transformation: "foobar_transformation"
+    }
+
+  vault_attribute :bad_role_transform,
+    transform_secret: {
+      transformation: "social_sec",
+      role: "foobar_role"
     }
 
   def encryption_context

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -38,6 +38,12 @@ class Person < ActiveRecord::Base
   vault_attribute :context_proc,
     context: ->(record) { record.encryption_context }
 
+  vault_attribute :transform_ssn,
+    encrypted_column: :transform_ssn,
+    transform_secret: {
+      transformation: "social_sec"
+    }
+
   def encryption_context
     "user_#{id}"
   end

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -13,6 +13,7 @@ class CreatePeople < ActiveRecord::Migration[4.2]
       t.string :context_string_encrypted
       t.string :context_symbol_encrypted
       t.string :context_proc_encrypted
+      t.string :transform_ssn
 
       t.timestamps null: false
     end

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -13,7 +13,7 @@ class CreatePeople < ActiveRecord::Migration[4.2]
       t.string :context_string_encrypted
       t.string :context_symbol_encrypted
       t.string :context_proc_encrypted
-      t.string :transform_ssn
+      t.string :transform_ssn_encrypted
 
       t.timestamps null: false
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2015_04_28_220101) do
     t.string "context_string_encrypted"
     t.string "context_symbol_encrypted"
     t.string "context_proc_encrypted"
+    t.string "transform_ssn"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2015_04_28_220101) do
     t.string "context_string_encrypted"
     t.string "context_symbol_encrypted"
     t.string "context_proc_encrypted"
-    t.string "transform_ssn"
+    t.string "transform_ssn_encrypted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,30 @@ require "vault/rails"
 
 require "rspec"
 
+def vault_version_string
+  @vault_version_string ||= `vault --version`
+end
+
+TEST_VAULT_VERSION = Gem::Version.new(vault_version_string.match(/(\d+\.\d+\.\d+)/)[1])
+
 RSpec.configure do |config|
   # Prohibit using the should syntax
   config.expect_with :rspec do |spec|
     spec.syntax = :expect
   end
+
+  # Allow tests to isolate a specific test using +focus: true+. If nothing
+  # is focused, then all tests are executed.
+  config.filter_run_when_matching :focus
+  config.filter_run_excluding vault: lambda { |v|
+    !vault_meets_requirements?(v)
+  }
+  config.filter_run_excluding ent_vault: lambda { |v|
+    !vault_is_enterprise? || !vault_meets_requirements?(v)
+  }
+  config.filter_run_excluding non_ent_vault: lambda { |v|
+    vault_is_enterprise? || !vault_meets_requirements?(v)
+  }
 
   # Allow tests to isolate a specific test using +focus: true+. If nothing
   # is focused, then all tests are executed.
@@ -19,6 +38,14 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+end
+
+def vault_is_enterprise?
+  !!vault_version_string.match(/\+(?:ent|prem)/)
+end
+
+def vault_meets_requirements?(v)
+  Gem::Requirement.new(v).satisfied_by?(TEST_VAULT_VERSION)
 end
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "appraisal", "~> 2.1"
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake",    "~> 10.0"
   s.add_development_dependency "rspec",   "~> 3.2"
   s.add_development_dependency "sqlite3"

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", [">= 4.1"]
-  s.add_dependency "vault", "~> 0.5"
+  s.add_dependency "vault", "~> 0.14"
 
   s.add_development_dependency "appraisal", "~> 2.1"
   s.add_development_dependency "bundler"


### PR DESCRIPTION
### ENTERPRISE VAULT ONLY

## Description

The vault ruby gem was updated to allow usage of the transform secrets engine a little while back. This PR allows for the usage of that engine within rails, extending the `vault_attribute` class function to accept a `transform_secret` hash that allows for the usage of FPE with a vault-internal tweak_source. Support for additional tweak_sources and transformation types may be provided in the future.

Similar to the Transit engine already implemented, this functionality uses a db column either provided by the user with the `encrypted_column` option, or uses the `vault_attribute` name provided with a `_encrypted` appended as a suffix (e.g. `vault_attribute :ssn` will have `ssn_encrypted` as the column that stores the value.

Note: due to constraints from ActiveRecord, we do NOT encourage people to use the name of the attribute as the column name (i.e. specifying `encrypted_column: 'ssn'` for the above example). The reason is this causes some instance attribute collisions that creates some confusion on the exact state of the data, particularly after calling `reload` on the object.

### Usage Instructions

Currently, the only fields accepted by the `transform_secrets` hash are:
 * `transformation` - required - String of the transformation name
 * `role` - String of the role name to be using the given transformation

All configuration of a given transformation should be done in vault, either via the [HTTP API](https://www.vaultproject.io/api-docs/secret/transform) (which [vault-ruby](https://github.com/hashicorp/vault-ruby) uses), or via the Vault CLI. Information on how to do so can be found [here](https://learn.hashicorp.com/vault/adp/transform).