### PR TITLE
Don't use Attributes API while it's private in Rails 4.2

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -59,8 +59,9 @@ module Vault
         # Make a note of this attribute so we can use it in the future (maybe).
         __vault_attributes[attribute.to_sym] = parsed_opts
 
-        self.attribute attribute.to_s, ActiveRecord::Type::Value.new,
-          default: nil
+        if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+          self.attribute attribute.to_s, ActiveRecord::Type::Value.new, default: nil
+        end
 
         # Getter
         define_method("#{attribute}") do


### PR DESCRIPTION
## Description

The Attributes API, introduced in Rails 5.0, is present in Rails 4.2 but is intentionally marked as internal API that shouldn't be depended on (it was in active development at the time).

While it might be likely that there's no perceivable change in behavior, there's no reason to risk compatibility issues in EOL versions of Rails that don't claim to support this API.
