### PR TITLE
Fix dirty nil assignments

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -237,7 +237,7 @@ module Vault
           self.__vault_load_attribute!(attribute, options)
         end
 
-        @__vault_loaded = self.class.__vault_attributes.all? { |attribute, __| instance_variable_get("@#{attribute}") }
+        @__vault_loaded = self.class.__vault_attributes.all? { |attribute, __| instance_variable_defined?("@#{attribute}") }
 
         return true
       end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -48,6 +48,16 @@ describe Vault::Rails do
       expect(person.ssn).to be(nil)
     end
 
+    it "allows dirty attributes to be unset" do
+      person = Person.create!(ssn: "123-45-6789")
+      person.ssn = nil
+      expect(person.ssn).to be_nil
+
+      person2 = Person.create!(ssn: "123-45-6789")
+      person2.assign_attributes(ssn: nil)
+      expect(person2.ssn).to be_nil
+    end
+
     it "allows saving without validations" do
       person = Person.new(ssn: "123-456-7890")
       person.save(validate: false)
@@ -140,6 +150,12 @@ describe Vault::Rails do
       expect(person.ssn_changed?).to be(true)
       expect(person.ssn_change).to eq(["123-45-6789", "111-11-1111"])
       expect(person.ssn_was).to eq("123-45-6789")
+
+      person.assign_attributes(ssn: "222-22-2222")
+
+      expect(person.ssn_changed?).to be(true)
+      expect(person.ssn_change).to eq(["123-45-6789", "222-22-2222"])
+      expect(person.ssn_was).to eq("123-45-6789")
     end
 
     it "allows attributes to be unset" do
@@ -149,6 +165,17 @@ describe Vault::Rails do
 
       expect(person.ssn).to be(nil)
     end
+
+    it "allows dirty attributes to be unset" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+      person.ssn = nil
+      expect(person.ssn).to be_nil
+
+      person2 = LazyPerson.create!(ssn: "123-45-6789")
+      person2.assign_attributes(ssn: nil)
+      expect(person2.ssn).to be_nil
+    end
+
 
     it "allows saving without validations" do
       person = LazyPerson.new(ssn: "123-456-7890")


### PR DESCRIPTION
## Description

Fixes a regression caused by https://github.com/hashicorp/vault-rails/pull/99/commits/6c5b1a3c2a6e1f9e7e7f228dee9ce6e1717ce548

The usage of instance_variable_get means that if an attribute is assigned to `nil`, the variable to signal that attributes are loaded is `false` - meaning that any intentional setting of `nil` results in attributes getting reloaded on the next read and wiping that `nil` value back to whatever it was before. I've added some specs to describe this behavior.