### PR TITLE
Drop Rails 4.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,6 @@ jobs:
             export VAULT_VERSION=<< parameters.vault-version >>
             export RAILS_VERSION=<< parameters.rails-version >>
             ruby --version
-            # Downgrade Bundler to 1.x
-            gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-            gem install bundler -v '< 2'
             bundle -v
             bundle install --jobs=4 --retry=3 --path=vendor/bundle
             bundle exec rake app:db:create

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           matrix:
             parameters:
               ruby-version: ["2.6", "2.5"]
-              rails-version: ["6.0.0", "5.2.0", "5.1.0", "5.0.0", "4.2.0"]
+              rails-version: ["6.0.0", "5.2.0", "5.1.0", "5.0.0"]
               vault-version: ["1.4.2", "1.4.1", "1.4.0", "1.3.6"]
           name: test-ruby-<< matrix.ruby-version >>-rails-<< matrix.rails-version >>-vault-<< matrix.vault-version >>
       - build-release:

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -97,6 +97,11 @@ describe Vault::Rails do
       person.name = "Cinderella"
       person.save!
     end
+
+    it "does not register a Vault attribute as necessarily being backed by a column" do
+      expect(Person.attribute_names).to include("ssn")
+      expect(Person.column_names).not_to include("ssn")
+    end
   end
 
   context "lazy decrypt" do

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.2"
+  s.add_dependency "rails", ">= 5.0"
   s.add_dependency "vault", "~> 0.14"
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
## Description

These changes:

* Drop support for Rails 4.2, _which really already happened with the 0.6.0 release_ (see below)
* Remove forceful usage of Bundler 1.x in CI (which was only required because of Rails 4.x)

---

In #67, Rails 5+ support was added in the form of ditching our own dirty attribute logic and instead utilizing the fancy new Attributes API, which was officially introduced in Rails 5 but present (sorta) in Rails 4.2 as well. This very obviously cut off support of vault-rails for Rails 4.1, which doesn't have this API at all. Tests passed for Rails 4.2, so it looked good.

However, the Attributes API in Rails 4.2 is actually totally private API - it's no more than a refactoring in anticipation of the real API in 5, and some of the API was accidentally exposed in documentation anyway in the 4.2 release.

The whole point of the Attributes API is to provide a separation between ActiveModel attributes and the real database columns behind them (if any!), allowing you to flexibly cast types when putting and retrieving data from the database. However, in Rails 4.2 the API is simply a refactoring and the separation there doesn't exist: attributes are one-to-one with database columns.

When vault-rails began to use the Attributes API in 0.6.0, a subtle behavior change occurred (for all versions of Rails): a `vault_attribute` is now registered as a real model attribute.

This change is fine...in Rails 5+. In modern versions, ActiveRecord is smart enough to know that this defined attribute is _not_ backed by a database column, and is omitted from things that expect a column to exist.

In Rails 4.2, it's not. The newly discovered attribute is expected to be backed by a database column, and things depend heavily on this expectation. This is evident via complex queries utilizing joins and where conditions, which generate aliases through intermediate tables, e.g.:

```
SELECT "dogs"."id" AS t0_r0, "dogs"."owner_id" AS t0_r1, ........
```

These queries are generated with a model's columns in mind, so you will now get an error with 0.6.0 and Rails 4.2 (where current_thought is a vault_attribute):

```
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column dogs.current_thought does not exist
LINE 1: ...AS t3_r38, "dogs"."current_thought" AS t3_r39, "dogs"."u...
```

Conclusion: As Rails 4.2 is long EOL'd anyway and we do *not* wish to maintain the old implementation alongside using the Attributes API for that single old Rails version, I propose 0.6.x as supporting only Rails 5+, and 0.5.0 will be the last known compatible version with Rails =< 4.2.