### PR TITLE
remove stray "require pry"

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -1,4 +1,3 @@
-require "pry"
 require "active_support/concern"
 
 module Vault


### PR DESCRIPTION
## Description

There's a stray `require "pry"` on current master that causes issues outside of the development and test environments - pry is a development dependency, so unless `pry` is loaded by the calling application in production, this `require` produces a `LoadError`:

<details>
<summary>Expand for full stack trace</summary>

```
rake aborted!
LoadError: cannot load such file -- pry
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:292:in `require'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:292:in `block in require'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:258:in `load_dependency'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:292:in `require'
/app/vendor/bundle/ruby/2.6.0/bundler/gems/vault-rails-b84fe08c0897/lib/vault/encrypted_model.rb:1:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/bundler/gems/vault-rails-b84fe08c0897/lib/vault/rails.rb:6:in `require_relative'
/app/vendor/bundle/ruby/2.6.0/bundler/gems/vault-rails-b84fe08c0897/lib/vault/rails.rb:6:in `<top (required)>'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:95:in `require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:95:in `rescue in block in require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:72:in `block in require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler.rb:114:in `require'
/app/config/application.rb:13:in `<top (required)>'
/app/Rakefile:4:in `require_relative'
/app/Rakefile:4:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:18:in `start'
/usr/local/bundle/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'

Caused by:
LoadError: cannot load such file -- vault-rails
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `each'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `block in require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler.rb:114:in `require'
/app/config/application.rb:13:in `<top (required)>'
/app/Rakefile:4:in `require_relative'
/app/Rakefile:4:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:18:in `start'
/usr/local/bundle/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```


</details>

