### PR TITLE
allow lazy decrypted vault attributes to be referenced after a destroy

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -216,6 +216,12 @@ module Vault
       # before theirs, resulting in attributes that are not persisted.
       after_save :__vault_persist_attributes!
 
+      # Before destroying a record, ensure that all vault attributes have been
+      # decrypted. Otherwise, attempting to read a lazily decrypted attribute
+      # after a destroy will result in a "Can't modify frozen Hash" error when
+      # vault-rails attempts to set the plain-text attribute.
+      before_destroy :__vault_load_attributes!, unless: -> { @__vault_loaded }
+
       # Decrypt all the attributes from Vault.
       # @return [true]
       def __vault_initialize_attributes!

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -112,6 +112,13 @@ describe Vault::Rails do
       expect(Person.attribute_names).to include("ssn")
       expect(Person.column_names).not_to include("ssn")
     end
+
+    it "does not reload encrypted attributes on destroy" do
+      person = Person.create!(ssn: "123-45-6789")
+
+      expect(Vault::Rails).to_not receive(:decrypt)
+      person.destroy
+    end
   end
 
   context "lazy decrypt" do
@@ -221,6 +228,13 @@ describe Vault::Rails do
       expect(Vault::Rails).to_not receive(:encrypt)
       person.name = "Cinderella"
       person.save!
+    end
+
+    it "allows attributes to be accessed after a destroy" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+
+      person.destroy
+      expect { person.ssn }.not_to raise_error
     end
   end
 
@@ -346,6 +360,13 @@ describe Vault::Rails do
       expect(Vault::Rails).to_not receive(:encrypt)
       person.name = "Cinderella"
       person.save!
+    end
+
+    it "allows attributes to be accessed after a destroy" do
+      person = LazyPerson.create!(ssn: "123-45-6789")
+
+      person.destroy
+      expect { person.ssn }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
After destroying a record, ActiveRecord marks the in-memory object as frozen and unable to be altered. This was fine in older versions of Rails prior to the attributes API, and it's mostly fine now. However, if lazy decrypt is enabled and you need to access an encrypted attribute after the destroy happens -- for instance, as part of a `dependent: :destroy` chain -- vault-rails attempts to set the plaintext attribute on the frozen object, raising a "Can't modify frozen hash" error.

As a workaround, this PR ensures that attributes are decrypted before a destroy so the plain text values can be accessed by after-destroy hooks if needed.

Currently, I've set this as universal behavior, since being able to access encrypted attributes after a destroy was the default prior to https://github.com/hashicorp/vault-rails/pull/67. However, another possibility would be only enabling this behavior for specific attributes, via something along these lines:

```
vault_attribute :details,
  access_after_destroy: true
```