### PR TITLE
Remove remaining Rails 5.0 thru 6.0 deprecations

### DIFF
--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -33,4 +33,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Use native SQLite integers as booleans in Rails 5.2+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.2")
+    config.active_record.sqlite3.represent_boolean_as_integer = true
+  end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -38,4 +38,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Use native SQLite integers as booleans in Rails 5.2+
+  if ActiveRecord.gem_version >= Gem::Version.new("5.2")
+    config.active_record.sqlite3.represent_boolean_as_integer = true
+  end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -42,7 +42,7 @@ describe Vault::Rails do
 
     it "allows attributes to be unset" do
       person = Person.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to be(nil)
@@ -67,7 +67,7 @@ describe Vault::Rails do
     it "allows attributes to be unset after reload" do
       person = Person.create!(ssn: "123-45-6789")
       person.reload
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to be(nil)
@@ -75,7 +75,7 @@ describe Vault::Rails do
 
     it "allows attributes to be blank" do
       person = Person.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: "")
+      person.update!(ssn: "")
       person.reload
 
       expect(person.ssn).to eq("")
@@ -84,7 +84,7 @@ describe Vault::Rails do
 
     it "allows attributes to be null" do
       person = Person.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to eq(nil)
@@ -172,7 +172,7 @@ describe Vault::Rails do
 
     it "allows attributes to be unset" do
       person = LazyPerson.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to be(nil)
@@ -198,7 +198,7 @@ describe Vault::Rails do
     it "allows attributes to be unset after reload" do
       person = LazyPerson.create!(ssn: "123-45-6789")
       person.reload
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to be(nil)
@@ -206,7 +206,7 @@ describe Vault::Rails do
 
     it "allows attributes to be blank" do
       person = LazyPerson.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: "")
+      person.update!(ssn: "")
       person.reload
 
       expect(person.ssn).to eq("")
@@ -270,7 +270,7 @@ describe Vault::Rails do
 
     it "does not decrypt all attributes on single read" do
       person = LazySinglePerson.create!(ssn: "123-45-6789")
-      person.update_attributes!(credit_card: "abcd-efgh-hijk-lmno")
+      person.update!(credit_card: "abcd-efgh-hijk-lmno")
       expect(person.credit_card).to eq("abcd-efgh-hijk-lmno")
 
       person.reload
@@ -285,7 +285,7 @@ describe Vault::Rails do
 
     it "does not decrypt all attributes on single write" do
       person = LazySinglePerson.create!(ssn: "123-45-6789")
-      person.update_attributes!(credit_card: "abcd-efgh-hijk-lmno")
+      person.update!(credit_card: "abcd-efgh-hijk-lmno")
       expect(person.credit_card).to eq("abcd-efgh-hijk-lmno")
 
       person.reload
@@ -315,7 +315,7 @@ describe Vault::Rails do
 
     it "allows attributes to be unset" do
       person = LazySinglePerson.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to be(nil)
@@ -330,7 +330,7 @@ describe Vault::Rails do
     it "allows attributes to be unset after reload" do
       person = LazySinglePerson.create!(ssn: "123-45-6789")
       person.reload
-      person.update_attributes!(ssn: nil)
+      person.update!(ssn: nil)
       person.reload
 
       expect(person.ssn).to be(nil)
@@ -338,7 +338,7 @@ describe Vault::Rails do
 
     it "allows attributes to be blank" do
       person = LazySinglePerson.create!(ssn: "123-45-6789")
-      person.update_attributes!(ssn: "")
+      person.update!(ssn: "")
       person.reload
 
       expect(person.ssn).to eq("")
@@ -406,7 +406,7 @@ describe Vault::Rails do
 
     it "allows attributes to be unset" do
       person = Person.create!(credit_card: "1234567890111213")
-      person.update_attributes!(credit_card: nil)
+      person.update!(credit_card: nil)
       person.reload
 
       expect(person.credit_card).to be(nil)
@@ -414,7 +414,7 @@ describe Vault::Rails do
 
     it "allows attributes to be blank" do
       person = Person.create!(credit_card: "1234567890111213")
-      person.update_attributes!(credit_card: "")
+      person.update!(credit_card: "")
       person.reload
 
       expect(person.credit_card).to eq("")
@@ -457,7 +457,7 @@ describe Vault::Rails do
 
     it "allows attributes to be unset" do
       person = Person.create!(non_ascii: "dás ümlaut")
-      person.update_attributes!(non_ascii: nil)
+      person.update!(non_ascii: nil)
       person.reload
 
       expect(person.non_ascii).to be(nil)
@@ -465,7 +465,7 @@ describe Vault::Rails do
 
     it "allows attributes to be blank" do
       person = Person.create!(non_ascii: "dás ümlaut")
-      person.update_attributes!(non_ascii: "")
+      person.update!(non_ascii: "")
       person.reload
 
       expect(person.non_ascii).to eq("")


### PR DESCRIPTION
## Description

Removes the remaining deprecation warnings that make their way in to CI output in all supported versions of Rails.