### PR TITLE
Loosen dependency to only ActiveSupport

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 5.0"
+  s.add_dependency "activesupport", ">= 5.0"
   s.add_dependency "vault", "~> 0.14"
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
## Description

This gem utilizes ActiveSupport, specifically, and doesn't need to have a hard dependency on the 'rails' metagem itself.

This is a topical change at the moment with https://github.com/rails/rails/issues/41750; if an application does not use ActiveStorage and ActionMailbox, it may choose specifically include the Rails components it needs instead of `rails` itself to avoid installing the mimemagic gem. Even if you aren't actually using the mimemagic functionality, transient dependencies - like this gem - must also not require it.

As this gem doesn't require anything other than ActiveSupport, we'll loosen constraints this gem imposes. 