### PR TITLE
Use vault-ruby 0.17.0 to add automatic retry on 412 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Vault Rails Changelog
 
+## v0.8.0 (May 23, 2022)
+
+IMPROVEMENTS
+
+- Added `Vault::MissingRequiredStateError` to list of error types to be retried automatically in `with_retries` and updated `vault` gem minimum version requirement accordingly
+
 ## v0.7.1 (March 24th, 2021)
 
 - Relaxed the dependency requirements for the gem to only depend on ActiveSupport, not the Rails meta gem, which

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -249,7 +249,7 @@ module Vault
       private
 
       def with_retries(client = self.client, &block)
-        exceptions = [Vault::HTTPConnectionError, Vault::HTTPServerError]
+        exceptions = [Vault::HTTPConnectionError, Vault::HTTPServerError, Vault::MissingRequiredStateError]
         options = {
           attempts: self.retry_attempts,
           base:     self.retry_base,

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.7.1"
+    VERSION = "0.8.0"
   end
 end

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "activesupport", ">= 5.0"
-  s.add_dependency "vault", "~> 0.14"
+  s.add_dependency "vault", "~> 0.17"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry"


### PR DESCRIPTION
## Description
The vault-ruby gem [now has the ability](https://github.com/hashicorp/vault-ruby/pull/266) to retry on 412 errors (caused by a mismatch between the WAL index on a standby node and the token; see [Server-Side Consistent Tokens FAQ](https://www.vaultproject.io/docs/faq/ssct)).

This PR updates the minimum required version of the vault gem and ensures that the vault-rails gem's version of the `with_retries` method passes the new error type (`Vault::MissingRequiredStateError`) as something to automatically retry on.