### PR TITLE
resolve issues with CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - v1-dependencies-bundler-<< parameters.ruby-version >>-{{ checksum "vault.gemspec" }}
+            - v2-dependencies-bundler-<< parameters.ruby-version >>-{{ checksum "vault.gemspec" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-bundler-
+            - v2-dependencies-bundler-
       - run:
           name: Install vault
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     machine:
       image: *UBUNTU_IMAGE
-    shell: /usr/bin/env bash -euo pipefail -c
+    shell: /usr/bin/env bash -eo pipefail -c
     parameters:
       ruby-version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 references:
   images:
-    ubuntu: &UBUNTU_IMAGE ubuntu-1604:202004-01
+    ubuntu: &UBUNTU_IMAGE ubuntu-2004:202201-02
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Fun story! CI [suddenly started failing](https://app.circleci.com/pipelines/github/hashicorp/vault-rails/134/workflows/c6a0fcb4-6e9a-450b-9e02-2688df12b5dc/jobs/2810) due to an SSL error when downloading the Vault binary from releases.hashicorp.com:
https://github.com/hashicorp/vault-rails/blob/8c953255b7d8f18c95e284e49e2596df5f9efe10/.circleci/config.yml#L33

Upon further investigation, this proved to be due to [an outdated SSL library](https://www.zoocha.com/news/fixing-issues-multiple-servers-caused-recently-expired-root-certificate).

It _also_ turns out that Circle is going to be deprecating the (super old) Ubuntu 16.04 image we were using on May 31, 2022, which is in, uh, 6 days. So let's kill two birds with one stone and update Ubuntu.
