### PR TITLE
Add automated copyright headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 version: 2.1
 
 orbs:

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,21 @@
+schema_version = 1
+
+project {
+  # (OPTIONAL) SPDX-compatible license identifier
+  # Leave blank if you don't wish to license the project
+  # Default: "MPL-2.0"
+  license = "MPL-2.0"
+
+  # (OPTIONAL) Represents the year that the project initially began
+  # Default: <the year the repo was first created>
+  copyright_year = 2015
+
+  # (OPTIONAL) A list of globs that should not have copyright or license headers .
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  # Default: []
+  header_ignore = [
+    # "vendors/**",
+    # "**autogen**",
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Vault Rails Changelog
 
+## UNRELEASED
+
+- Added HashiCorp, Inc. copyright statements to source code files.
+
 ## v0.8.0 (May 23, 2022)
 
 IMPROVEMENTS

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 source "https://rubygems.org"
 
 RAILS_VERSION = ENV.fetch("RAILS_VERSION", "6.0.0")

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "active_support/concern"
 
 module Vault

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "vault"
 
 require "base64"

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 module Vault
   module Rails
     module Configurable

--- a/lib/vault/rails/errors.rb
+++ b/lib/vault/rails/errors.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 module Vault
   module Rails
     class VaultRailsError < RuntimeError; end

--- a/lib/vault/rails/json_serializer.rb
+++ b/lib/vault/rails/json_serializer.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 module Vault
   module Rails
     module JSONSerializer

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 module Vault
   module Rails
     VERSION = "0.8.0"

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "binary_serializer"
 
 class LazyPerson < ActiveRecord::Base

--- a/spec/dummy/app/models/lazy_single_person.rb
+++ b/spec/dummy/app/models/lazy_single_person.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 class LazySinglePerson < ActiveRecord::Base
   include Vault::EncryptedModel

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "binary_serializer"
 
 class Person < ActiveRecord::Base

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 default: &default
   adapter: sqlite3
   pool: 5

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/dummy/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/spec/dummy/config/initializers/cookies_serializer.rb
+++ b/spec/dummy/config/initializers/cookies_serializer.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/spec/dummy/config/initializers/filter_parameter_logging.rb
+++ b/spec/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/spec/dummy/config/initializers/inflections.rb
+++ b/spec/dummy/config/initializers/inflections.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/spec/dummy/config/initializers/mime_types.rb
+++ b/spec/dummy/config/initializers/mime_types.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_dummy_session'

--- a/spec/dummy/config/initializers/vault.rb
+++ b/spec/dummy/config/initializers/vault.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "vault/rails"
 
 require_relative "../../../support/vault_server"

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
 # than English, add the necessary files in this directory.

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 Rails.application.routes.draw do
 
 end

--- a/spec/dummy/config/secrets.yml
+++ b/spec/dummy/config/secrets.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 class CreatePeople < ActiveRecord::Migration[4.2]
   def change
     create_table :people do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/dummy/lib/binary_serializer.rb
+++ b/spec/dummy/lib/binary_serializer.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Encodes and decodes binary data.
 module BinarySerializer
   def self.encode(raw)

--- a/spec/dummy/public/404.html
+++ b/spec/dummy/public/404.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+ Copyright (c) HashiCorp, Inc.
+ SPDX-License-Identifier: MPL-2.0
+-->
+
 <html>
 <head>
   <title>The page you were looking for doesn't exist (404)</title>

--- a/spec/dummy/public/422.html
+++ b/spec/dummy/public/422.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+ Copyright (c) HashiCorp, Inc.
+ SPDX-License-Identifier: MPL-2.0
+-->
+
 <html>
 <head>
   <title>The change you wanted was rejected (422)</title>

--- a/spec/dummy/public/500.html
+++ b/spec/dummy/public/500.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+ Copyright (c) HashiCorp, Inc.
+ SPDX-License-Identifier: MPL-2.0
+-->
+
 <html>
 <head>
   <title>We're sorry, but something went wrong (500)</title>

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -1,4 +1,7 @@
 # encoding: utf-8
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 require "spec_helper"
 

--- a/spec/lib/vault/rails/json_serializer_spec.rb
+++ b/spec/lib/vault/rails/json_serializer_spec.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require 'spec_helper'
 
 RSpec.describe Vault::Rails::JSONSerializer do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "vault/rails"
 

--- a/spec/support/vault_server.rb
+++ b/spec/support/vault_server.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "open-uri"
 require "singleton"
 require "timeout"

--- a/spec/unit/encrypted_model_spec.rb
+++ b/spec/unit/encrypted_model_spec.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "spec_helper"
 
 describe Vault::EncryptedModel do

--- a/spec/unit/rails/configurable_spec.rb
+++ b/spec/unit/rails/configurable_spec.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "spec_helper"
 
 describe Vault::Rails::Configurable do

--- a/spec/unit/rails_spec.rb
+++ b/spec/unit/rails_spec.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require "spec_helper"
 
 describe Vault::Rails do

--- a/spec/unit/vault/rails_spec.rb
+++ b/spec/unit/vault/rails_spec.rb
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 require 'spec_helper'
 
 RSpec.describe Vault::Rails do


### PR DESCRIPTION
This PR adds copyright statements to source code files, automatically generated by a HashiCorp internal tool.

This will be included in the next Rubygem release.