### PR TITLE
Implement vault batch_input to decrypt multiple attributes efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UNRELEASED
 
 - Added HashiCorp, Inc. copyright statements to source code files.
+- Add vault_batch_decrypt which implements vault decrypt batch_input to reduce the number of
+    outbound calls when an encrypted model has multiple vault attributes
 
 ## v0.8.0 (May 23, 2022)
 

--- a/spec/dummy/app/models/lazy_batch_person.rb
+++ b/spec/dummy/app/models/lazy_batch_person.rb
@@ -1,0 +1,52 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+require "binary_serializer"
+
+class LazyBatchPerson < ActiveRecord::Base
+  include Vault::EncryptedModel
+
+  self.table_name = "people"
+
+  vault_lazy_decrypt!
+  vault_batch_decrypt!
+
+  vault_attribute :ssn
+
+  vault_attribute :credit_card,
+    encrypted_column: :cc_encrypted,
+    path: "credit-secrets",
+    key: "people_credit_cards"
+
+  vault_attribute :details,
+    serialize: :json
+
+  vault_attribute :business_card,
+    serialize: BinarySerializer
+
+  vault_attribute :favorite_color,
+    encode: ->(raw) { "xxx#{raw}xxx" },
+    decode: ->(raw) { raw && raw[3...-3] }
+
+  vault_attribute :non_ascii
+
+  vault_attribute :default,
+    default: "abc123"
+
+  vault_attribute :default_with_serializer,
+    serialize: :json,
+    default: {}
+
+  vault_attribute :context_string,
+    context: "production"
+
+  vault_attribute :context_symbol,
+    context: :encryption_context
+
+  vault_attribute :context_proc,
+    context: ->(record) { record.encryption_context }
+
+  def encryption_context
+    "user_#{id}"
+  end
+end


### PR DESCRIPTION
## Description
As currently implemented,  __vault_load_attributes loops over __vault_load_attribute if vault_single_decrypt is disabled. In the case where an encrypted model has many vault attributes this will incur a vault load per attribute. 
Vault supports batch_input/batch_results on the decrypt API which allows loading all of the decrypted data for multiple attributes in a single vault call. 

This adds the decrypt_all call to Vault::Rails which internally uses batch_input. 
Also added is support code to use this and some test code to verify correctness.