### PR TITLE
CI refactor

### DIFF
--- a/spec/support/vault_server.rb
+++ b/spec/support/vault_server.rb
@@ -18,6 +18,7 @@ module RSpec
     end
 
     attr_reader :token
+    attr_reader :unseal_token
 
     def initialize
       # If there is already a vault-token, we need to move it so we do not
@@ -30,7 +31,10 @@ module RSpec
       end
 
       io = Tempfile.new("vault-server")
-      pid = Process.spawn({}, "vault server -dev", out: io.to_i, err: io.to_i)
+      pid = Process.spawn(
+        "vault server -dev -dev-root-token-id=root",
+        out: io.to_i, err: io.to_i
+      )
 
       at_exit do
         Process.kill("INT", pid)
@@ -39,9 +43,23 @@ module RSpec
         io.close
         io.unlink
       end
+      wait_for_ready
+      puts "vault server is ready"
+      # sleep to get unseal token
+      sleep 5
 
-      wait_for_ready do
-        @token = File.read(TOKEN_PATH)
+      @token = "root"
+
+      output = ""
+      while io.rewind
+        output = io.read
+        break unless output.empty?
+      end
+
+      if output.match(/Unseal Key.*: (.+)/)
+        @unseal_token = $1.strip
+      else
+        raise "Vault did not return an unseal token!"
       end
     end
 
@@ -49,16 +67,23 @@ module RSpec
       "http://127.0.0.1:8200"
     end
 
-    def wait_for_ready(&block)
-      Timeout.timeout(5) do
-        while !File.exist?(TOKEN_PATH)
-          sleep(0.25)
+    def wait_for_ready
+      uri = URI(address + "/v1/sys/health")
+      Timeout.timeout(15) do
+        loop do
+          begin
+            response = Net::HTTP.get_response(uri)
+            if response.code != 200
+              return true
+            end
+          rescue Errno::ECONNREFUSED
+            puts "waiting for vault to start"
+          end
+          sleep 2
         end
       end
-
-      yield
     rescue Timeout::Error
-      raise "Vault did not start in 5 seconds!"
+      raise TimeoutError, "Timed out waiting for vault health check"
     end
   end
 end


### PR DESCRIPTION
same as https://github.com/hashicorp/vault-ruby/pull/294

The main change here is to not read the ~/.vault-token file for the token, just hard-code it.
this takes out the race condition that was happening and allows us to have more consistent CI runs