### PR TITLE
TF-8697: Update `vault` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Added HashiCorp, Inc. copyright statements to source code files.
 
+## v0.9.0 (September 14, 2023)
+
+IMPROVEMENTS
+
+- Updated the `vault` dependency to `v0.18.0` to support TLS v1.3.
+
 ## v0.8.0 (May 23, 2022)
 
 IMPROVEMENTS

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -3,6 +3,6 @@
 
 module Vault
   module Rails
-    VERSION = "0.8.0"
+    VERSION = "0.9.0"
   end
 end

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "activesupport", ">= 5.0"
-  s.add_dependency "vault", "~> 0.17"
+  s.add_dependency "vault", "~> 0.18"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry"


### PR DESCRIPTION
## Description

Updating `vault` dependency to support TLS v1.3 (https://github.com/hashicorp/vault-ruby/pull/297).