### PR TITLE
Updating README to clarify that keys use attribute by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ vault_attribute :credit_card,
 - **Note** This value **cannot** be the same name as the vault attribute!
 
 #### Specifying a custom key
-By default, the name of the key in Vault is `#{app}_#{table}_#{column}`. This is customizable by setting the `:key` option when declaring the attribute:
+By default, the name of the key in Vault is `#{app}_#{table}_#{attribute}`. This is customizable by setting the `:key` option when declaring the attribute:
 
 ```ruby
 vault_attribute :credit_card,


### PR DESCRIPTION
## Description
The key [by default uses the attribute name](https://github.com/hashicorp/vault-rails/blob/main/lib/vault/encrypted_model.rb#L184) and not the column name. So this just updates the README to avoid confusion.
