### PR TITLE
Update vault-ruby, Ruby 3.1+, etc for a 0.11.0 release

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: hashicorp/vault-rails/run-tests
+name: Tests
 on:
   push:
     branches:
@@ -10,13 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         # https://endoflife.date/ruby
-        ruby: ["2.7", "3.0", "3.1", "3.3"]
-        vault: ["1.11.9", "1.19.5", "1.20.4", "1.21.0"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        vault: ["1.16.3", "1.19.5", "1.20.4", "1.21.1"]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: ruby/setup-ruby@ab177d40ee5483edb974554986f56b33477e21d0 # v1.265.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Vault Rails Changelog
 
+## v0.11.0 (December 3, 2025)
+
+BREAKING CHANGES
+
+- Set minimum Ruby version to 3.1. All EOL Ruby versions are no longer supported.
+
+IMPROVEMENTS
+
+- Updated the `vault` dependency to `~> 0.19` which includes upgraded `net-http-persistent` and `connection_pool` dependencies, improved connection handling, and Ruby 3.4 compatibility.
+- Added Ruby 3.2 and 3.4 to CI matrix; removed EOL Ruby versions 2.7 and 3.0.
+- Updated Vault versions in CI matrix to 1.16, 1.19, 1.20, and 1.21.
+
 ## v0.10.0 (November 7, 2025)
 
 IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Vault Rails [![Build Status](https://circleci.com/gh/hashicorp/vault-rails.svg?style=shield)](https://circleci.com/gh/hashicorp/vault-rails)
+Vault Rails [![Build Status](https://github.com/hashicorp/vault-rails/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/hashicorp/vault-rails/actions/workflows/run-tests.yml)
 ===========
 
 Vault is the official Rails plugin for interacting with [Vault](https://vaultproject.io) by HashiCorp.

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -3,6 +3,6 @@
 
 module Vault
   module Rails
-    VERSION = "0.10.0"
+    VERSION = "0.11.0"
   end
 end

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -17,8 +17,16 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
+  s.required_ruby_version = ">= 3.1"
+
   s.add_dependency "activesupport", ">= 5.0"
-  s.add_dependency "vault", "~> 0.18"
+  s.add_dependency "vault", "~> 0.19"
+  # mutex_m was removed from Ruby's default gems in 3.4.0
+  # Rails 6.0 depends on it but doesn't declare it explicitly
+  s.add_dependency "mutex_m"
+  # bigdecimal was removed from Ruby's default gems in 3.4.0
+  # Rails 6.0 depends on it but doesn't declare it explicitly
+  s.add_dependency "bigdecimal"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pry"
@@ -26,4 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",    "~> 12.3.3"
   s.add_development_dependency "rspec",   "~> 3.2"
   s.add_development_dependency "sqlite3", "~> 1.3.6"
+  # ostruct will be removed from Ruby's default gems in 3.5.0
+  # rake 12.3.3 depends on it but doesn't declare it explicitly
+  s.add_development_dependency "ostruct"
 end


### PR DESCRIPTION
## Description

Like it says on the can. Utilizing all the goodness here:

https://github.com/hashicorp/vault-ruby/releases/tag/v0.19.0